### PR TITLE
Suggestions for organizing the core tests

### DIFF
--- a/core/src/main/scala/com/softwaremill/react/kafka/commit/ConsumerCommitter.scala
+++ b/core/src/main/scala/com/softwaremill/react/kafka/commit/ConsumerCommitter.scala
@@ -14,7 +14,9 @@ import scala.language.postfixOps
 /**
  * This should become deprecated as soon as we remove KafkaActorSubscriber/KafkaActorPublisher and related stuff.
  */
-private[commit] class ConsumerCommitter[K, V](
+// Commenting out the package private, to make tests more distant from code (using separate package names). AKa270216
+//private[commit]
+class ConsumerCommitter[K, V](
     consumerActor: ActorRef,
     consumerProperties: ConsumerProperties[_, _]
 ) extends Actor with ActorLogging {

--- a/core/src/test/scala/ConsumerCommitterTest.scala
+++ b/core/src/test/scala/ConsumerCommitterTest.scala
@@ -1,11 +1,12 @@
-package com.softwaremill.react.kafka.commit
+package test
 
 import akka.actor._
 import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
+import com.softwaremill.react.kafka._
+import com.softwaremill.react.kafka.commit.{Offsets, OffsetMap, ConsumerCommitter}
 import com.softwaremill.react.kafka.KafkaActorPublisher.{CommitAck, CommitOffsets}
-import com.softwaremill.react.kafka.{ConsumerProperties, KafkaTest}
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.serialization.StringDeserializer
@@ -16,7 +17,9 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class ConsumerCommitterSpec extends TestKit(ActorSystem(
+import test.tools.KafkaTest
+
+class ConsumerCommitterTest extends TestKit(ActorSystem(
   "ConsumerCommitterSpec",
   ConfigFactory.parseString("""akka.loggers = ["akka.testkit.TestEventListener"]""")
 )) with ImplicitSender with fixture.FlatSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach

--- a/core/src/test/scala/ConsumerPropertiesTest.scala
+++ b/core/src/test/scala/ConsumerPropertiesTest.scala
@@ -1,7 +1,8 @@
-package com.softwaremill.react.kafka
+package test
 
 import java.util.UUID
 
+import com.softwaremill.react.kafka.ConsumerProperties
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.scalatest._
 

--- a/core/src/test/scala/ProducerPropertiesTest.scala
+++ b/core/src/test/scala/ProducerPropertiesTest.scala
@@ -1,7 +1,8 @@
-package com.softwaremill.react.kafka
+package test
 
 import java.util.UUID
 
+import com.softwaremill.react.kafka.ProducerProperties
 import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
 import org.scalatest._
 

--- a/core/src/test/scala/ReactiveKafkaIntegrationTest.scala
+++ b/core/src/test/scala/ReactiveKafkaIntegrationTest.scala
@@ -1,4 +1,4 @@
-package com.softwaremill.react.kafka
+package test
 
 import java.util.concurrent.{ConcurrentLinkedQueue, TimeUnit}
 
@@ -9,6 +9,8 @@ import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import com.softwaremill.react.kafka.KafkaMessages._
+import com.softwaremill.react.kafka.ProducerMessage
+import com.softwaremill.react.kafka.tools.ReactiveKafkaIntegrationTestSupport
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{Matchers, fixture}
@@ -17,7 +19,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class ReactiveKafkaIntegrationSpec extends TestKit(ActorSystem("ReactiveKafkaIntegrationSpec"))
+class ReactiveKafkaIntegrationTest extends TestKit(ActorSystem("ReactiveKafkaIntegrationSpec"))
     with ImplicitSender with fixture.WordSpecLike with Matchers
     with ReactiveKafkaIntegrationTestSupport with MockitoSugar {
 
@@ -117,18 +119,4 @@ class ReactiveKafkaIntegrationSpec extends TestKit(ActorSystem("ReactiveKafkaInt
     }
   }
 
-}
-
-class ReactiveTestSubscriber extends ActorSubscriber {
-
-  protected def requestStrategy = WatermarkRequestStrategy(10)
-
-  var elements: Vector[StringConsumerRecord] = Vector.empty
-
-  def receive = {
-
-    case ActorSubscriberMessage.OnNext(element) =>
-      elements = elements :+ element.asInstanceOf[StringConsumerRecord]
-    case "get elements" => sender ! elements
-  }
 }

--- a/core/src/test/scala/ReactiveKafkaSubscriberTest.scala
+++ b/core/src/test/scala/ReactiveKafkaSubscriberTest.scala
@@ -1,15 +1,16 @@
-package com.softwaremill.react.kafka
+package test
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Keep, Flow, Sink}
 import akka.stream.testkit.scaladsl.TestSource
+import com.softwaremill.react.kafka.{ProducerMessage, ReactiveKafka, ProducerProperties}
 import kafka.producer.ReactiveKafkaProducer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.scalatest.FlatSpec
 
-class ReactiveKafkaSubscriberSpec extends FlatSpec {
+class ReactiveKafkaSubscriberTest extends FlatSpec {
 
   implicit val actorSystem = ActorSystem("test")
   implicit val materializer = ActorMaterializer()

--- a/core/src/test/scala/tools/ReactiveKafkaIntegrationTestSupport.scala
+++ b/core/src/test/scala/tools/ReactiveKafkaIntegrationTestSupport.scala
@@ -1,14 +1,14 @@
-package com.softwaremill.react.kafka
+package com.softwaremill.react.kafka.tools
 
 import java.util.UUID
-import java.util.concurrent.ConcurrentLinkedQueue
 
 import akka.stream.scaladsl.Sink
 import akka.testkit.TestKit
+import com.softwaremill.react.kafka.ProducerProperties
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.scalatest.fixture.Suite
+import test.tools.KafkaTest
 
-import scala.collection.JavaConverters._
 import scala.language.postfixOps
 
 trait ReactiveKafkaIntegrationTestSupport extends Suite with KafkaTest {

--- a/core/src/test/scala/tools/ReactiveKafkaPublisherSpec.scala
+++ b/core/src/test/scala/tools/ReactiveKafkaPublisherSpec.scala
@@ -1,10 +1,11 @@
-package com.softwaremill.react.kafka
+package test.tools
 
 import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Sink, Source}
 import com.softwaremill.react.kafka.KafkaMessages.StringConsumerRecord
+import com.softwaremill.react.kafka.{ConsumerProperties, ProducerProperties}
 import kafka.producer.ReactiveKafkaProducer
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.producer.ProducerRecord

--- a/core/src/test/scala/tools/ReactiveKafkaSubscriberBlackboxSpec.scala
+++ b/core/src/test/scala/tools/ReactiveKafkaSubscriberBlackboxSpec.scala
@@ -1,9 +1,10 @@
-package com.softwaremill.react.kafka
+package test.tools
 
 import java.util.UUID
 
 import akka.stream.scaladsl.{Sink, Source}
 import com.softwaremill.react.kafka.KafkaMessages.StringProducerMessage
+import com.softwaremill.react.kafka.{ProducerMessage, ProducerProperties}
 import org.reactivestreams.tck.{SubscriberBlackboxVerification, TestEnvironment}
 import org.reactivestreams.{Publisher, Subscriber}
 import org.scalatest.testng.TestNGSuiteLike

--- a/core/src/test/scala/tools/ReactiveKafkaSubscriberWhiteboxSpec.scala
+++ b/core/src/test/scala/tools/ReactiveKafkaSubscriberWhiteboxSpec.scala
@@ -1,9 +1,10 @@
-package com.softwaremill.react.kafka
+package test.tools
 
 import java.util.UUID
 
 import akka.stream.scaladsl.{Sink, Source}
 import com.softwaremill.react.kafka.KafkaMessages._
+import com.softwaremill.react.kafka.{ProducerMessage, ProducerProperties}
 import org.reactivestreams.tck.SubscriberWhiteboxVerification.{SubscriberPuppet, WhiteboxSubscriberProbe}
 import org.reactivestreams.tck.{SubscriberWhiteboxVerification, TestEnvironment}
 import org.reactivestreams.{Subscriber, Subscription}

--- a/core/src/test/scala/tools/ReactiveStreamsTckVerificationBase.scala
+++ b/core/src/test/scala/tools/ReactiveStreamsTckVerificationBase.scala
@@ -1,4 +1,4 @@
-package com.softwaremill.react.kafka
+package test.tools
 
 import akka.actor.ActorSystem
 import org.scalatest.Suite


### PR DESCRIPTION
Here are some suggestions on how the tests could be made clearer to newcomers - and more detached from the code itself, which I see valuable. Please judge and discuss.

1. Tests should not be in the same namespace as implementation

This is a guideline I've taken to code I do myself. I would argue that it gives an absolute good (i.e. is not a matter of taste). It forces test code to be more like actual use cases, disallowing "peeks" into the internals of the implementation (one such actually spotted in this PR). Also, conceptually I feel it's clearer for understanding a project.

&nbsp;2. Namespace depth of tests does not matter

Since tests are not being published, they don't need to have unique namespaces. Any project can simply have its tests under `test` (or anything), without conflicts with other projects. This actually helps if working on the command line (IDE usually flattens directory structures to one-step anyways).

&nbsp;3. Would like to have unit tests and integration tests in different package

Those two are very different beasts. Unit tests are usually most important *before* the code is written, to set the bar on when a unit is done. After it is, they serve less purpose.

Integration tests are very important throughout a project, since they measure whether the whole is 'done' or not.

Separating the package names (e.g. `test` for integration and `test.unit` for unit tests) allows detecting references where these two domains mix (i.e. keeping unit tests actually unit tests), and more importantly, running unit tests only, for example with `sbt "testOnly core/*test.unit"`.

In this PR, I haven't filtered pure unit tests away from the tests, yet. All tests are in the `test` package.

&nbsp;4. Separating test tool coding from actual tests

When looking at tests, it's relevant to see what is tested. Therefore only the test code is in the root level of `core/src/test/scala` folder. Tools are placed under a `tools/´ folder. Note: they could probably use the normal `test` package, unlike the PR now has. Placing them in a separate package name has really no added benefit.

&nbsp;5. Unified Spec vs. Test postfix in class names

There may be also some other points of view - I'll comment them on the line wise comments, below.