### PR TITLE
Consumer tests

### DIFF
--- a/core/src/main/scala/com/softwaremill/react/kafka2/Consumer.scala
+++ b/core/src/main/scala/com/softwaremill/react/kafka2/Consumer.scala
@@ -6,7 +6,7 @@ import akka.stream._
 import akka.stream.scaladsl.{Source, Sink, GraphDSL, Flow}
 import akka.stream.stage._
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.kafka.clients.consumer.{ConsumerRecord, ConsumerRecords, OffsetAndMetadata, OffsetCommitCallback}
+import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
 
 import scala.collection.JavaConversions._
@@ -75,7 +75,7 @@ object ManualCommitConsumer {
   }
 }
 
-class ManualCommitConsumer[K, V](consumerProvider: ConsumerProvider[K, V])
+class ManualCommitConsumer[K, V](consumerProvider: () => KafkaConsumer[K, V])
     extends GraphStageWithMaterializedValue[ManualCommitConsumer.ConsumerShape[K, V], ManualCommitConsumer.Control]
     with LazyLogging {
   import ManualCommitConsumer._

--- a/core/src/main/scala/com/softwaremill/react/kafka2/Consumer.scala
+++ b/core/src/main/scala/com/softwaremill/react/kafka2/Consumer.scala
@@ -154,6 +154,9 @@ class ManualCommitConsumer[K, V](consumerProvider: () => KafkaConsumer[K, V])
         }
 
         override def onDownstreamFinish(): Unit = {
+          if (!isClosed(commitIn)) {
+            cancel(commitIn)
+          }
           poll()
         }
       })

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -5,12 +5,13 @@
         </encoder>
     </appender>
 
-    <logger name="org.apache" level="WARN"/>
-    <logger name="akka" level="WARN"/>
-    <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR"/>
-    <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>
+    <!--<logger name="akka" level="WARN"/>-->
+    <!--<logger name="org.apache.kafka" level="WARN"/>-->
+    <!--<logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR"/>-->
+    <!--<logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>-->
+    <!--<logger name="com.softwaremill.react" level="TRACE"/>-->
 
-    <root level="DEBUG">
+    <root level="WARN">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/core/src/test/scala/com/softwaremill/react/kafka2/ConsumerTest.scala
+++ b/core/src/test/scala/com/softwaremill/react/kafka2/ConsumerTest.scala
@@ -65,12 +65,13 @@ class ConsumerTest(_system: ActorSystem)
 
   it should "complete messages outlet when stream about to close" in {
     val (control, (in, out), sink) = graph(new ConsumerMock[K, V](), testFlow[Record, CommitInfo], TestSink.probe)
+    in.expectSubscription()
 
     sink.request(100)
 
     control.stop()
+    sink.expectNoMsg(200 millis)
     in.expectComplete()
-    out.expectNoMsg(100 millis)
 
     out.sendComplete()
     sink.expectComplete()

--- a/core/src/test/scala/com/softwaremill/react/kafka2/ConsumerTest.scala
+++ b/core/src/test/scala/com/softwaremill/react/kafka2/ConsumerTest.scala
@@ -1,0 +1,88 @@
+package com.softwaremill.react.kafka2
+
+import akka.actor.ActorSystem
+import akka.stream._
+import akka.stream.scaladsl._
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+import akka.testkit.TestKit
+import org.apache.kafka.clients.consumer.{ConsumerRecord, KafkaConsumer, OffsetAndMetadata}
+import org.apache.kafka.common.TopicPartition
+import org.mockito.Mockito
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FlatSpecLike, Matchers}
+
+import scala.concurrent.Future
+import scala.language.postfixOps
+
+/**
+ * @author Alexey Romanchuk
+ */
+
+object ConsumerTest {
+  def noopFlow[K, V] = Flow[ConsumerRecord[K, V]].map { r =>
+    Map(new TopicPartition(r.topic(), r.partition()) -> new OffsetAndMetadata(r.offset()))
+  }
+  def testFlow[I, O](implicit as: ActorSystem) = Flow.fromSinkAndSourceMat(TestSink.probe[I], TestSource.probe[O])(Keep.both)
+
+  def graph[Key, Value, FlowMat, SinkMat](
+    provider: ConsumerMock[Key, Value],
+    processing: Flow[ConsumerRecord[Key, Value], Map[TopicPartition, OffsetAndMetadata], FlowMat],
+    confirmation: Sink[Future[Map[TopicPartition, OffsetAndMetadata]], SinkMat]
+  )(implicit m: Materializer) = {
+    val graph = GraphDSL.create(
+      new ManualCommitConsumer[Key, Value](() => provider.mock),
+      processing,
+      confirmation
+    )(Tuple3.apply) { implicit b => (kafka, processing, confirmation) =>
+        import GraphDSL.Implicits._
+
+        kafka.messages ~> processing ~> kafka.commit
+        kafka.confirmation ~> confirmation
+        ClosedShape
+      }
+    RunnableGraph.fromGraph(graph).run()
+  }
+}
+
+class ConsumerTest(_system: ActorSystem)
+    extends TestKit(_system)
+    with FlatSpecLike
+    with Matchers
+    with MockitoSugar {
+  def this() = this(ActorSystem())
+
+  implicit val m = ActorMaterializer(ActorMaterializerSettings(_system).withFuzzing(true))
+  implicit val ec = _system.dispatcher
+
+  type K = String
+  type V = String
+  type Record = ConsumerRecord[K, V]
+  type CommitInfo = Map[TopicPartition, OffsetAndMetadata]
+
+  import ConsumerTest._
+
+  import scala.concurrent.duration._
+
+  it should "complete messages outlet when stream about to close" in {
+    val (control, (in, out), sink) = graph(new ConsumerMock[K, V](), testFlow[Record, CommitInfo], TestSink.probe)
+
+    sink.request(100)
+
+    control.stop()
+    in.expectComplete()
+    out.expectNoMsg(100 millis)
+
+    out.sendComplete()
+    sink.expectComplete()
+
+    ()
+  }
+}
+
+class ConsumerMock[K, V]() {
+  val mock = {
+    val result = Mockito.mock(classOf[KafkaConsumer[K, V]])
+
+    result
+  }
+}

--- a/core/src/test/scala/com/softwaremill/react/kafka2/ConsumerTest.scala
+++ b/core/src/test/scala/com/softwaremill/react/kafka2/ConsumerTest.scala
@@ -235,7 +235,7 @@ class ConsumerTest(_system: ActorSystem)
 
     messages.expectComplete()
     confirmationOut.expectNext()
-    confirmationOut.expectNoMsg()
+    confirmationOut.expectNoMsg(200 millis)
 
     //emulate commit
     commitLog.calls.head match {
@@ -243,6 +243,7 @@ class ConsumerTest(_system: ActorSystem)
     }
 
     confirmationOut.expectComplete()
+    mock.verifyClosed()
     ()
   }
 }

--- a/core/src/test/scala/com/softwaremill/react/kafka2/ProducerTest.scala
+++ b/core/src/test/scala/com/softwaremill/react/kafka2/ProducerTest.scala
@@ -106,7 +106,7 @@ class ProducerTest(_system: ActorSystem)
 
     // Here we can not be sure that all messages from source delivered to producer
     // because of buffers in akka-stream and faster error pushing that ignores buffers
-    // So we just check that all futures that we emmited successfully completed
+    // So we just check that all futures that we emitted successfully completed
 
     Await.ready(sink, 500 millis)
     sink.value should matchPattern {

--- a/core/src/test/scala/com/softwaremill/react/kafka2/ProducerTest.scala
+++ b/core/src/test/scala/com/softwaremill/react/kafka2/ProducerTest.scala
@@ -29,8 +29,7 @@ import scala.util.{Try, Failure, Success}
 class ProducerTest(_system: ActorSystem)
     extends TestKit(_system)
     with FlatSpecLike
-    with Matchers
-    with MockitoSugar {
+    with Matchers {
   def this() = this(ActorSystem())
 
   implicit val m = ActorMaterializer(ActorMaterializerSettings(_system).withFuzzing(true))


### PR DESCRIPTION
- base tests for consumer
- separate timeouts for data fetching and offset commit
- prevent multiple poll scheduling
- correct cancellation handling for confirmationOut