### PR TITLE
Fix for not committing offsets for partitions which are no longer own…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: scala
+sudo: false
+scala:
+  - "2.11.8"
+jdk:
+  - oraclejdk8
+before_install:
+- wget http://apache.mirrors.spacedump.net/kafka/0.9.0.1/kafka_2.11-0.9.0.1.tgz -O kafka.tgz
+- mkdir -p kafka && tar xzf kafka.tgz -C kafka --strip-components 1
+- nohup bash -c "cd kafka && bin/zookeeper-server-start.sh config/zookeeper.properties &"
+- nohup bash -c "cd kafka && bin/kafka-server-start.sh config/server.properties &"
+- sleep 5
+env:
+  matrix:
+    - SCRIPT="sbt -jvm-opts .travis-jvmopts test"
+# important to use eval, otherwise "&&" is passed as an argument to sbt rather than being processed by bash
+script: eval $SCRIPT
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot

--- a/core/src/main/scala/com/softwaremill/react/kafka/KafkaActorPublisher.scala
+++ b/core/src/main/scala/com/softwaremill/react/kafka/KafkaActorPublisher.scala
@@ -38,7 +38,7 @@ private[kafka] class KafkaActorPublisher[K, V](consumerAndProps: ReactiveKafkaCo
     try {
       consumer.commitSync(offsets.toCommitRequestInfo)
       log.debug(s"committed offsets: $offsets")
-      sender() ! CommitAck
+      sender() ! CommitAck(offsets)
     }
     catch {
       case ex: Exception =>

--- a/core/src/main/scala/com/softwaremill/react/kafka/commit/ConsumerCommitter.scala
+++ b/core/src/main/scala/com/softwaremill/react/kafka/commit/ConsumerCommitter.scala
@@ -82,7 +82,7 @@ private[commit] class ConsumerCommitter[K, V](
   }
 
   private def handleAck(offsetMap: OffsetMap): Unit = {
-    committedOffsetMap = OffsetMap(offsetMap.map.mapValues(_ - 1))
+    committedOffsetMap = committedOffsetMap.merge(offsetMap)
   }
 
 }

--- a/core/src/main/scala/com/softwaremill/react/kafka/commit/OffsetMap.scala
+++ b/core/src/main/scala/com/softwaremill/react/kafka/commit/OffsetMap.scala
@@ -17,6 +17,9 @@ case class OffsetMap(map: Offsets = Map.empty) {
 
   def toFetchRequestInfo = map.keys.toSeq
 
+  def merge(other: OffsetMap) =
+    OffsetMap(map ++ other.map)
+
   def toCommitRequestInfo = {
     // Kafka expects the offset of the first unfetched message, and we have the
     // offset of the last fetched message


### PR DESCRIPTION
…ed by this consumer instance

PR for #118 

Successful commits do not update `partitionOffsetMap`. Thus, one ends up committing the same offset on a partition repeatedly. This gets ugly when a partition is no longer assigned to this consumer instance. This is because in such cases we keep committing to the broker a stale fixed offset from this consumer which no in-fact no longer owns this partition.

Fix involves updating the `partitionOffsetMap` with successfully committed offsets (once we get a commit confirmation from the broker). 
Have tested this under load  of ~50,000 messages/sec by adding and removing consumer instances extremely frequently.