### PR TITLE
Expose topic partitions to API

### DIFF
--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -14,6 +14,7 @@ import akka.kafka.internal.PlainConsumerStage
 import akka.stream.scaladsl.Source
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import akka.stream.ActorAttributes
+import org.apache.kafka.common.TopicPartition
 
 /**
  * Akka Stream connector for subscribing to Kafka topics.
@@ -171,5 +172,9 @@ object Consumer {
     }
   }
 
+  def committablePartitionedSource[K, V](settings: ConsumerSettings[K, V]):
+    Source[(TopicPartition, Source[CommittableMessage[K, V], Control]), Control] = {
+    ???
+  }
 }
 


### PR DESCRIPTION
In this PR, I propose an API which exposes topic partitions. This API allows:
- backpressure per partition
- react to partition assignment and revoking

The idea here is to react to an automatic partition assignment (`subscribe` and `ConsumerRebalanceListener`) and emit a nested `Source` when partition assigned and close this `Source` when partition revoked. 