### PR TITLE
Correct udpate of the committer state for ConsumerCommitter

### DIFF
--- a/core/src/main/scala/com/softwaremill/react/kafka/commit/ConsumerCommitter.scala
+++ b/core/src/main/scala/com/softwaremill/react/kafka/commit/ConsumerCommitter.scala
@@ -84,7 +84,7 @@ private[commit] class ConsumerCommitter[T](committerFactory: CommitterProvider, 
         log.debug(s"committed offsets: $resultOffsetMap")
         // We got the offset of the first unfetched message, and we want the
         // offset of the last fetched message
-        committedOffsetMap = OffsetMap(resultOffsetMap.map.mapValues(_ - 1))
+        committedOffsetMap = OffsetMap(committedOffsetMap.map ++ resultOffsetMap.map.mapValues(_ - 1))
       case scala.util.Failure(ex) =>
         log.error(ex, "Failed to commit offsets")
         committer.tryRestart() match {


### PR DESCRIPTION
The issues causes unnecessary re-committing of already committed offsets. There was a similar issue with KafkaCommitterSink which was fixed ([here](https://github.com/akka/reactive-kafka/commit/c691e194ac355b6c2df208a8ece54d8df501fee4)). The ConsumerCommitter which uses the same logic was, however,  not patched at the same time. The following PR corrects that. 
