### PR TITLE
TopicPartition API

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -33,12 +33,6 @@ akka.kafka.consumer {
   # is executing the stage will be blocked.
   poll-timeout = 50ms
   
-  # Tuning property of the `KafkaConsumer.poll` parameter when there
-  # are outstanding offset commit requests.
-  # Note that non-zero value means that blocking of the thread that
-  # is executing the stage will be blocked.
-  poll-commit-timeout = 1ms
-  
   # The stage will be await outstanding offset commit requests before
   # shutting down, but if that takes longer than this timeout it will
   # stop forcefully.

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -7,11 +7,10 @@ package akka.kafka
 import java.util.Optional
 import java.util.concurrent.CompletionStage
 
-import scala.compat.java8.FutureConverters._
-import scala.concurrent.Future
-
 import akka.Done
 import akka.kafka.internal.ConsumerStage.CommittableOffsetBatchImpl
+
+import scala.concurrent.Future
 
 /**
  * Classes that are used in both [[javadsl.Consumer]] and
@@ -50,7 +49,6 @@ object ConsumerMessage {
    */
   trait Committable {
     def commitScaladsl(): Future[Done]
-
     def commitJavadsl(): CompletionStage[Done]
   }
 

--- a/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.kafka
+
+import java.util
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.regex.Pattern
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props, Status, Terminated}
+import akka.event.LoggingReceive
+import org.apache.kafka.clients.consumer._
+import org.apache.kafka.common.TopicPartition
+
+import scala.collection.JavaConverters._
+
+object KafkaConsumerActor {
+  case class StoppingException() extends RuntimeException("Kafka consumer is stopping")
+  def props[K, V](settings: ConsumerSettings[K, V]): Props = {
+    Props(new KafkaConsumerActor(settings)).withDispatcher(settings.dispatcher)
+  }
+
+  object Internal {
+    //requests
+    private[kafka] final case class Assign(tps: Set[TopicPartition])
+    private[kafka] final case class AssignWithOffset(tps: Map[TopicPartition, Long])
+    private[kafka] final case class Subscribe(topics: Set[String], listener: ConsumerRebalanceListener)
+    private[kafka] final case class SubscribePattern(pattern: String, listener: ConsumerRebalanceListener)
+    private[kafka] final case class RequestMessages(topics: Set[TopicPartition])
+    private[kafka] case object Stop
+    private[kafka] final case class Commit(offsets: Map[TopicPartition, Long])
+    //responses
+    private[kafka] final case class Assigned(partition: List[TopicPartition])
+    private[kafka] final case class Revoked(partition: List[TopicPartition])
+    private[kafka] final case class Messages[K, V](messages: Iterator[ConsumerRecord[K, V]])
+    private[kafka] final case class Committed(offsets: Map[TopicPartition, OffsetAndMetadata])
+    //internal
+    private[KafkaConsumerActor] case object Poll
+  }
+
+  private val number = new AtomicInteger()
+  private[kafka] def nextNumber() = {
+    number.incrementAndGet()
+  }
+
+  private[kafka] def rebalanceListener(onAssign: Iterable[TopicPartition] => Unit, onRevoke: Iterable[TopicPartition] => Unit) = new ConsumerRebalanceListener {
+    override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit = {
+      onAssign(partitions.asScala)
+    }
+    override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit = {
+      onRevoke(partitions.asScala)
+    }
+  }
+}
+
+private[kafka] class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V])
+    extends Actor with ActorLogging {
+  import KafkaConsumerActor.Internal._
+  import KafkaConsumerActor._
+
+  def pollTimeout() = settings.pollTimeout
+  def pollInterval() = settings.pollInterval
+
+  var requests = Map.empty[TopicPartition, ActorRef]
+  var consumer: KafkaConsumer[K, V] = _
+  var nextScheduledPoll: Option[Cancellable] = None
+  var pollExpected = false
+  var commitsInProgress = 0
+  var stopInProgress = false
+
+  def receive: Receive = LoggingReceive {
+    case Assign(tps) =>
+      val previousAssigned = consumer.assignment()
+      consumer.assign((tps.toSeq ++ previousAssigned.asScala).asJava)
+    case AssignWithOffset(tps) =>
+      val previousAssigned = consumer.assignment()
+      consumer.assign((tps.keys.toSeq ++ previousAssigned.asScala).asJava)
+      tps.foreach {
+        case (tp, offset) => consumer.seek(tp, offset)
+      }
+    case Commit(offsets) =>
+      val commitMap = offsets.mapValues(new OffsetAndMetadata(_))
+      val reply = sender()
+      commitsInProgress += 1
+      consumer.commitAsync(commitMap.asJava, new OffsetCommitCallback {
+        override def onComplete(offsets: util.Map[TopicPartition, OffsetAndMetadata], exception: Exception): Unit = {
+          commitsInProgress -= 1
+          if (exception != null) reply ! Status.Failure(exception)
+          else reply ! Committed(offsets.asScala.toMap)
+        }
+      })
+      //right now we can not store commits in consumer - https://issues.apache.org/jira/browse/KAFKA-3412
+      pollExpected = true
+      poll()
+    case Subscribe(topics, listener) =>
+      consumer.subscribe(topics.toList.asJava, listener)
+    case SubscribePattern(pattern, listener) =>
+      consumer.subscribe(Pattern.compile(pattern), listener)
+    case Poll =>
+      pollExpected = true
+      poll()
+    case RequestMessages(topics) =>
+      context.watch(sender())
+      requests ++= topics.map(_ -> sender()).toMap
+      pollExpected = true
+      poll()
+    case Stop =>
+      if (commitsInProgress == 0) {
+        context.stop(self)
+      }
+      else {
+        stopInProgress = true
+        context.become(stopping)
+      }
+    case Terminated(ref) =>
+      requests = requests.filter(_._2 == ref)
+  }
+
+  def stopping: Receive = LoggingReceive {
+    case Poll =>
+      pollExpected = true
+      poll()
+    case Stop =>
+    case _: Terminated =>
+    case msg @ (_: Commit | _: RequestMessages) =>
+      sender() ! Status.Failure(StoppingException())
+    case msg @ (_: Assign | _: AssignWithOffset | _: Subscribe | _: SubscribePattern) =>
+      log.warning("Got unexpected message {} when KafkaConsumerActor is in stopping state", msg)
+  }
+
+  override def preStart(): Unit = {
+    super.preStart()
+    requests = Map.empty[TopicPartition, ActorRef]
+    consumer = settings.createKafkaConsumer()
+    nextScheduledPoll = None
+    commitsInProgress = 0
+    pollExpected = false
+    schedulePoll()
+  }
+
+  override def postStop(): Unit = {
+    nextScheduledPoll.foreach(_.cancel())
+    consumer.close()
+    super.postStop()
+  }
+
+  def poll() = {
+    if (pollExpected) {
+      pollExpected = false
+      nextScheduledPoll.foreach(_.cancel())
+      nextScheduledPoll = None
+
+      //set partitions to fetch
+      val partitionsToFetch = requests.keys.toSet
+      consumer.assignment().asScala.foreach { tp =>
+        if (partitionsToFetch.contains(tp)) consumer.resume(tp)
+        else consumer.pause(tp)
+      }
+
+      val rawResult = consumer.poll(pollTimeout().toMillis)
+      if (!rawResult.isEmpty) {
+        // split tps by reply actor
+        val replyByTP = requests
+          .groupBy { case (tp, ref) => ref }
+          .mapValues(_.keys.toSet)
+
+        //send messages to actors
+        replyByTP.foreach {
+          case (ref, tps) =>
+            //gather all messages for ref
+            val messages = tps.foldLeft[Iterator[ConsumerRecord[K, V]]](Iterator.empty) {
+              case (acc, tp) =>
+                val tpMessages = rawResult.records(tp).asScala.iterator
+                if (acc.isEmpty) tpMessages
+                else acc ++ tpMessages
+            }
+            if (messages.nonEmpty) {
+              ref ! Messages(messages)
+            }
+        }
+        //check the we got only requested partitions and did not drop any messages
+        require((rawResult.partitions().asScala -- requests.keys).isEmpty)
+
+        //remove tps for which we got messages
+        requests --= rawResult.partitions().asScala
+      }
+      if (stopInProgress && commitsInProgress == 0) {
+        context.stop(self)
+      }
+      else {
+        schedulePoll()
+      }
+    }
+  }
+
+  def schedulePoll(): Unit = {
+    if (nextScheduledPoll.isEmpty) {
+      import context.dispatcher
+      nextScheduledPoll = Some(context.system.scheduler.scheduleOnce(pollInterval(), self, Poll))
+    }
+  }
+}

--- a/core/src/main/scala/akka/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ProducerSettings.scala
@@ -4,14 +4,15 @@
  */
 package akka.kafka
 
-import scala.concurrent.duration._
-import scala.collection.JavaConverters._
+import java.util.concurrent.TimeUnit
+
 import akka.actor.ActorSystem
 import akka.kafka.internal.ConfigSettings
 import com.typesafe.config.Config
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig}
 import org.apache.kafka.common.serialization.Serializer
-import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration._
 
 object ProducerSettings {
 

--- a/core/src/main/scala/akka/kafka/internal/ConfigSettings.scala
+++ b/core/src/main/scala/akka/kafka/internal/ConfigSettings.scala
@@ -4,9 +4,7 @@
  */
 package akka.kafka.internal
 
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigObject
-import com.typesafe.config.ConfigValue
+import com.typesafe.config.{Config, ConfigObject, ConfigValue}
 
 /**
  * INTERNAL API

--- a/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.kafka.internal
+
+import akka.actor.{ActorRef, Terminated}
+import akka.kafka.Subscriptions.{Assignment, AssignmentWithOffset}
+import akka.kafka.{KafkaConsumerActor, ManualSubscription}
+import akka.stream.SourceShape
+import akka.stream.stage.GraphStageLogic.StageActor
+import akka.stream.stage.{GraphStageLogic, OutHandler}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+
+import scala.annotation.tailrec
+
+private[kafka] abstract class ExternalSingleSourceLogic[K, V, Msg](
+    val shape: SourceShape[Msg],
+    consumer: ActorRef,
+    subscription: ManualSubscription
+) extends GraphStageLogic(shape) with PromiseControl with MessageBuilder[K, V, Msg] {
+  var tps = Set.empty[TopicPartition]
+  var buffer: Iterator[ConsumerRecord[K, V]] = Iterator.empty
+  var requested = false
+  var self: StageActor = _
+
+  override def preStart(): Unit = {
+    super.preStart()
+    subscription match {
+      case Assignment(topics) =>
+        consumer ! KafkaConsumerActor.Internal.Assign(topics)
+        tps ++= topics
+      case AssignmentWithOffset(topics) =>
+        consumer ! KafkaConsumerActor.Internal.AssignWithOffset(topics)
+        tps ++= topics.keySet
+    }
+
+    self = getStageActor {
+      case (sender, msg: KafkaConsumerActor.Internal.Messages[K, V]) =>
+        requested = false
+        // do not use simple ++ because of https://issues.scala-lang.org/browse/SI-9766
+        if (buffer.hasNext) {
+          buffer = buffer ++ msg.messages
+        }
+        else {
+          buffer = msg.messages
+        }
+        pump()
+      case (_, Terminated(ref)) if ref == consumer =>
+        failStage(new Exception("Consumer actor terminated"))
+    }
+    self.watch(consumer)
+  }
+
+  val partitionAssignedCB = getAsyncCallback[Iterable[TopicPartition]] { newTps =>
+    tps ++= newTps
+    pump()
+  }
+  val partitionRevokedCB = getAsyncCallback[Iterable[TopicPartition]] { newTps =>
+    tps --= newTps
+    pump()
+  }
+
+  @tailrec
+  private def pump(): Unit = {
+    if (isAvailable(shape.out)) {
+      if (buffer.hasNext) {
+        val msg = buffer.next()
+        push(shape.out, createMessage(msg))
+        pump()
+      }
+      else if (!requested && tps.nonEmpty) {
+        requested = true
+        consumer.tell(KafkaConsumerActor.Internal.RequestMessages(tps), self.ref)
+      }
+    }
+  }
+
+  setHandler(shape.out, new OutHandler {
+    override def onPull(): Unit = {
+      pump()
+    }
+  })
+
+  override def performShutdown() = {
+    completeStage()
+  }
+
+  override def postStop(): Unit = {
+    onShutdown()
+    super.postStop()
+  }
+}

--- a/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
@@ -6,16 +6,15 @@ package akka.kafka.internal
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.Future
-import scala.concurrent.Promise
-import scala.util.{Failure, Success, Try}
-import scala.util.control.NonFatal
-
-import akka.kafka.ProducerMessage._
+import akka.kafka.ProducerMessage.{Message, Result}
 import akka.kafka.ProducerSettings
 import akka.stream._
 import akka.stream.stage._
 import org.apache.kafka.clients.producer.{Callback, KafkaProducer, RecordMetadata}
+
+import scala.concurrent.{Future, Promise}
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success, Try}
 
 /**
  * INTERNAL API

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.kafka.internal
+
+import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
+import akka.kafka.Subscriptions.{Assignment, AssignmentWithOffset, TopicSubscription, TopicSubscriptionPattern}
+import akka.kafka.{ConsumerSettings, KafkaConsumerActor, Subscription}
+import akka.stream.stage.GraphStageLogic.StageActor
+import akka.stream.stage.{GraphStageLogic, OutHandler}
+import akka.stream.{ActorMaterializer, SourceShape}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+
+import scala.annotation.tailrec
+
+private[kafka] abstract class SingleSourceLogic[K, V, Msg](
+    val shape: SourceShape[Msg],
+    settings: ConsumerSettings[K, V],
+    subscription: Subscription
+) extends GraphStageLogic(shape) with PromiseControl with MessageBuilder[K, V, Msg] {
+  var consumer: ActorRef = _
+  var self: StageActor = _
+  var tps = Set.empty[TopicPartition]
+  var buffer: Iterator[ConsumerRecord[K, V]] = Iterator.empty
+  var requested = false
+  var shutdownStarted = false
+
+  override def preStart(): Unit = {
+    super.preStart()
+
+    consumer = {
+      val extendedActorSystem = ActorMaterializer.downcast(materializer).system.asInstanceOf[ExtendedActorSystem]
+      val name = s"kafka-consumer-${KafkaConsumerActor.nextNumber()}"
+      extendedActorSystem.systemActorOf(KafkaConsumerActor.props(settings), name)
+    }
+
+    subscription match {
+      case TopicSubscription(topics) =>
+        consumer ! KafkaConsumerActor.Internal.Subscribe(topics, KafkaConsumerActor.rebalanceListener(partitionAssignedCB.invoke, partitionRevokedCB.invoke))
+      case TopicSubscriptionPattern(topics) =>
+        consumer ! KafkaConsumerActor.Internal.SubscribePattern(topics, KafkaConsumerActor.rebalanceListener(partitionAssignedCB.invoke, partitionRevokedCB.invoke))
+      case Assignment(topics) =>
+        consumer ! KafkaConsumerActor.Internal.Assign(topics)
+        tps ++= topics
+      case AssignmentWithOffset(topics) =>
+        consumer ! KafkaConsumerActor.Internal.AssignWithOffset(topics)
+        tps ++= topics.keySet
+    }
+
+    self = getStageActor {
+      case (_, msg: KafkaConsumerActor.Internal.Messages[K, V]) =>
+        requested = false
+        // do not use simple ++ because of https://issues.scala-lang.org/browse/SI-9766
+        if (buffer.hasNext) {
+          buffer = buffer ++ msg.messages
+        }
+        else {
+          buffer = msg.messages
+        }
+        pump()
+      case (_, Terminated(ref)) if ref == consumer =>
+        failStage(new Exception("Consumer actor terminated"))
+    }
+    self.watch(consumer)
+  }
+
+  val partitionAssignedCB = getAsyncCallback[Iterable[TopicPartition]] { newTps =>
+    tps ++= newTps
+    pump()
+  }
+  val partitionRevokedCB = getAsyncCallback[Iterable[TopicPartition]] { newTps =>
+    tps --= newTps
+    pump()
+  }
+
+  @tailrec
+  private def pump(): Unit = {
+    if (isAvailable(shape.out)) {
+      if (buffer.hasNext) {
+        val msg = buffer.next()
+        push(shape.out, createMessage(msg))
+        pump()
+      }
+      else if (!requested && tps.nonEmpty) {
+        requested = true
+        consumer.tell(KafkaConsumerActor.Internal.RequestMessages(tps), self.ref)
+      }
+    }
+  }
+
+  setHandler(shape.out, new OutHandler {
+    override def onPull(): Unit = {
+      pump()
+    }
+
+    override def onDownstreamFinish(): Unit = {
+      performShutdown()
+    }
+  })
+
+  override def postStop(): Unit = {
+    consumer ! KafkaConsumerActor.Internal.Stop
+    super.postStop()
+  }
+
+  override def performShutdown() = {
+    setKeepGoing(true)
+    if (!isClosed(shape.out)) {
+      complete(shape.out)
+    }
+    self.become {
+      case (_, Terminated(ref)) if ref == consumer =>
+        onShutdown()
+        completeStage()
+    }
+    consumer ! KafkaConsumerActor.Internal.Stop
+  }
+}

--- a/core/src/main/scala/akka/kafka/internal/StageLogging.scala
+++ b/core/src/main/scala/akka/kafka/internal/StageLogging.scala
@@ -4,10 +4,9 @@
  */
 package akka.kafka.internal
 
-import akka.stream.stage.GraphStageLogic
-import akka.event.LoggingAdapter
+import akka.event.{LoggingAdapter, NoLogging}
 import akka.stream.ActorMaterializer
-import akka.event.NoLogging
+import akka.stream.stage.GraphStageLogic
 
 // TODO this can be removed when https://github.com/akka/akka/issues/18793 has been implemented
 trait StageLogging { self: GraphStageLogic =>

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.kafka.internal
+
+import akka.NotUsed
+import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
+import akka.kafka.Subscriptions.{TopicSubscription, TopicSubscriptionPattern}
+import akka.kafka.scaladsl.Consumer.Control
+import akka.kafka.{AutoSubscription, ConsumerSettings, KafkaConsumerActor}
+import akka.stream.scaladsl.Source
+import akka.stream.stage.GraphStageLogic.StageActor
+import akka.stream.stage._
+import akka.stream.{ActorMaterializer, Attributes, Outlet, SourceShape}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+
+import scala.annotation.tailrec
+import scala.collection.immutable
+
+private[kafka] abstract class SubSourceLogic[K, V, Msg](
+    val shape: SourceShape[(TopicPartition, Source[Msg, NotUsed])],
+    settings: ConsumerSettings[K, V],
+    subscription: AutoSubscription
+) extends GraphStageLogic(shape) with PromiseControl with MessageBuilder[K, V, Msg] {
+  var consumer: ActorRef = _
+  var self: StageActor = _
+  var buffer: immutable.Queue[TopicPartition] = immutable.Queue.empty
+  var subSources: Map[TopicPartition, Control] = immutable.Map.empty
+
+  override def preStart(): Unit = {
+    super.preStart()
+    consumer = {
+      val extendedActorSystem = ActorMaterializer.downcast(materializer).system.asInstanceOf[ExtendedActorSystem]
+      val name = s"kafka-consumer-${KafkaConsumerActor.nextNumber()}"
+      extendedActorSystem.systemActorOf(KafkaConsumerActor.props(settings), name)
+    }
+
+    subscription match {
+      case TopicSubscription(topics) =>
+        consumer ! KafkaConsumerActor.Internal.Subscribe(topics, KafkaConsumerActor.rebalanceListener(partitionAssignedCB.invoke, partitionRevokedCB.invoke))
+      case TopicSubscriptionPattern(topics) =>
+        consumer ! KafkaConsumerActor.Internal.SubscribePattern(topics, KafkaConsumerActor.rebalanceListener(partitionAssignedCB.invoke, partitionRevokedCB.invoke))
+    }
+
+    self = getStageActor {
+      case (_, Terminated(ref)) if ref == consumer =>
+        failStage(new Exception("Consumer actor terminated"))
+    }
+    self.watch(consumer)
+  }
+
+  val partitionAssignedCB = getAsyncCallback[Iterable[TopicPartition]] { tps =>
+    buffer = buffer.enqueue(tps.toList)
+    pump()
+  }
+  val partitionRevokedCB = getAsyncCallback[Iterable[TopicPartition]] { r =>
+    r.map(subSources.get).foreach(_.foreach(_.shutdown()))
+    subSources --= r
+  }
+
+  val subsourceCancelledCB = getAsyncCallback[TopicPartition] { tp =>
+    subSources -= tp
+    buffer :+= tp
+    pump()
+  }
+
+  val subsourceStartedCB = getAsyncCallback[(TopicPartition, Control)] {
+    case (tp, control) => subSources += (tp -> control)
+  }
+
+  setHandler(shape.out, new OutHandler {
+    override def onPull(): Unit = {
+      pump()
+    }
+    override def onDownstreamFinish(): Unit = {
+      performShutdown()
+    }
+  })
+
+  def createSource(tp: TopicPartition): Source[Msg, NotUsed] = {
+    Source.fromGraph(new SubSourceStage(tp, consumer))
+  }
+
+  @tailrec
+  private def pump(): Unit = {
+    if (buffer.nonEmpty && isAvailable(shape.out)) {
+      val (tp, remains) = buffer.dequeue
+      buffer = remains
+      push(shape.out, (tp, createSource(tp)))
+      pump()
+    }
+  }
+
+  override def postStop(): Unit = {
+    consumer ! KafkaConsumerActor.Internal.Stop
+    super.postStop()
+  }
+
+  override def performShutdown() = {
+    setKeepGoing(true)
+    //todo we should wait for subsources to be shutdown and next shutdown main stage
+    subSources.foreach {
+      case (_, control) => control.shutdown()
+    }
+
+    if (!isClosed(shape.out)) {
+      complete(shape.out)
+    }
+    self.become {
+      case (_, Terminated(ref)) if ref == consumer =>
+        onShutdown()
+        completeStage()
+    }
+    consumer ! KafkaConsumerActor.Internal.Stop
+  }
+
+  class SubSourceStage(tp: TopicPartition, consumer: ActorRef) extends GraphStage[SourceShape[Msg]] { stage =>
+    val out = Outlet[Msg]("out")
+    val shape = new SourceShape(out)
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
+      new GraphStageLogic(shape) with PromiseControl {
+        val shape = stage.shape
+        var requested = false
+        var self: StageActor = _
+        var buffer: Iterator[ConsumerRecord[K, V]] = Iterator.empty
+
+        override def preStart(): Unit = {
+          subsourceStartedCB.invoke((tp, this))
+          self = getStageActor {
+            case (_, msg: KafkaConsumerActor.Internal.Messages[K, V]) =>
+              requested = false
+              // do not use simple ++ because of https://issues.scala-lang.org/browse/SI-9766
+              if (buffer.hasNext) {
+                buffer = buffer ++ msg.messages
+              }
+              else {
+                buffer = msg.messages
+              }
+              pump()
+            case (_, Terminated(ref)) if ref == consumer =>
+              failStage(new Exception("Consumer actor terminated"))
+          }
+          self.watch(consumer)
+        }
+
+        override def postStop(): Unit = {
+          onShutdown()
+          super.postStop()
+        }
+
+        setHandler(out, new OutHandler {
+          override def onPull(): Unit = {
+            pump()
+          }
+
+          override def onDownstreamFinish(): Unit = {
+            subsourceCancelledCB.invoke(tp)
+            super.onDownstreamFinish()
+          }
+        })
+
+        def performShutdown() = {
+          completeStage()
+        }
+
+        @tailrec
+        private def pump(): Unit = {
+          if (isAvailable(out)) {
+            if (buffer.hasNext) {
+              val msg = buffer.next()
+              push(out, createMessage(msg))
+              pump()
+            }
+            else if (!requested) {
+              requested = true
+              consumer.tell(KafkaConsumerActor.Internal.RequestMessages(Set(tp)), self.ref)
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -8,9 +8,8 @@ import java.util.concurrent.CompletionStage
 
 import akka.Done
 import akka.kafka.ConsumerMessage._
-import akka.kafka.ConsumerSettings
 import akka.kafka.internal.ConsumerStage.WrappedConsumerControl
-import akka.kafka.scaladsl
+import akka.kafka.{ConsumerSettings, Subscription, scaladsl}
 import akka.stream.javadsl.Source
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
@@ -57,8 +56,8 @@ object Consumer {
    * possible, but when it is it will make the consumption fully atomic and give "exactly once" semantics that are
    * stronger than the "at-least once" semantics you get with Kafka's offset commit functionality.
    */
-  def plainSource[K, V](settings: ConsumerSettings[K, V]): Source[ConsumerRecord[K, V], Control] =
-    scaladsl.Consumer.plainSource(settings)
+  def plainSource[K, V](settings: ConsumerSettings[K, V], subscription: Subscription): Source[ConsumerRecord[K, V], Control] =
+    scaladsl.Consumer.plainSource(settings, subscription)
       .mapMaterializedValue(new WrappedConsumerControl(_))
       .asJava
 
@@ -75,8 +74,8 @@ object Consumer {
    * If you need to store offsets in anything other than Kafka, [[#plainSource]] should be used
    * instead of this API.
    */
-  def committableSource[K, V](settings: ConsumerSettings[K, V]): Source[CommittableMessage[K, V], Control] =
-    scaladsl.Consumer.committableSource(settings)
+  def committableSource[K, V](settings: ConsumerSettings[K, V], subscription: Subscription): Source[CommittableMessage[K, V], Control] =
+    scaladsl.Consumer.committableSource(settings, subscription)
       .mapMaterializedValue(new WrappedConsumerControl(_))
       .asJava
 
@@ -84,8 +83,8 @@ object Consumer {
    * Convenience for "at-most once delivery" semantics. The offset of each message is committed to Kafka
    * before emitted downstreams.
    */
-  def atMostOnceSource[K, V](settings: ConsumerSettings[K, V]): Source[Message[K, V], Control] =
-    scaladsl.Consumer.atMostOnceSource(settings)
+  def atMostOnceSource[K, V](settings: ConsumerSettings[K, V], subscription: Subscription): Source[Message[K, V], Control] =
+    scaladsl.Consumer.atMostOnceSource(settings, subscription)
       .mapMaterializedValue(new WrappedConsumerControl(_))
       .asJava
 

--- a/core/src/main/scala/akka/kafka/javadsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Producer.scala
@@ -5,14 +5,11 @@
 package akka.kafka.javadsl
 
 import akka.NotUsed
-import akka.kafka.ConsumerMessage
 import akka.kafka.ProducerMessage._
-import akka.kafka.ProducerSettings
+import akka.kafka.{ConsumerMessage, ProducerSettings}
 import akka.kafka.internal.ProducerStage
 import akka.stream.ActorAttributes
-import akka.stream.scaladsl.Flow
-import akka.stream.scaladsl.Keep
-import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.{Flow, Keep, Sink}
 import org.apache.kafka.clients.producer.ProducerRecord
 
 /**

--- a/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
@@ -5,14 +5,11 @@
 package akka.kafka.scaladsl
 
 import akka.NotUsed
-import akka.kafka.ConsumerMessage
 import akka.kafka.ProducerMessage._
-import akka.kafka.ProducerSettings
+import akka.kafka.{ConsumerMessage, ProducerSettings}
 import akka.kafka.internal.ProducerStage
 import akka.stream.ActorAttributes
-import akka.stream.scaladsl.Flow
-import akka.stream.scaladsl.Keep
-import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.{Flow, Keep, Sink}
 import org.apache.kafka.clients.producer.ProducerRecord
 
 /**

--- a/core/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
+++ b/core/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
@@ -20,7 +20,7 @@ class ConsumerSettingsSpec extends WordSpecLike with Matchers {
         akka.kafka.consumer.kafka-clients.foo = bar
         akka.kafka.consumer.kafka-clients.client.id = client1
         """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
-      val settings = ConsumerSettings(conf, new ByteArrayDeserializer, new StringDeserializer, Set("topic1"))
+      val settings = ConsumerSettings(conf, new ByteArrayDeserializer, new StringDeserializer)
       settings.getProperty("bootstrap.servers") should ===("localhost:9092")
       settings.getProperty("client.id") should ===("client1")
       settings.getProperty("foo") should ===("bar")

--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -13,6 +13,7 @@ import scala.concurrent.duration._
 
 import akka.Done
 import akka.actor.ActorSystem
+import akka.kafka.Subscriptions.TopicSubscription
 import akka.kafka.{ConsumerSettings, ProducerSettings}
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Keep, Source}
@@ -75,12 +76,12 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
         .map(n => new ProducerRecord(topic1, null: Array[Byte], n.toString))
         .runWith(Producer.plainSink(producerSettings))
 
-      val consumerSettings = ConsumerSettings(system, new ByteArrayDeserializer, new StringDeserializer, Set(topic1))
+      val consumerSettings = ConsumerSettings(system, new ByteArrayDeserializer, new StringDeserializer)
         .withBootstrapServers(bootstrapServers)
         .withGroupId(group1)
         .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
 
-      val probe = Consumer.plainSource(consumerSettings)
+      val probe = Consumer.plainSource(consumerSettings, TopicSubscription(Set(topic1)))
         // it's not 100% sure we get the first message, see https://issues.apache.org/jira/browse/KAFKA-3334
         .filterNot(_.value == InitialMsg)
         .map(_.value)
@@ -104,14 +105,14 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
         .map(n => new ProducerRecord(topic1, partition0, null: Array[Byte], n.toString))
         .runWith(Producer.plainSink(producerSettings))
 
-      val consumerSettings = ConsumerSettings(system, new ByteArrayDeserializer, new StringDeserializer, Set(topic1))
+      val consumerSettings = ConsumerSettings(system, new ByteArrayDeserializer, new StringDeserializer)
         .withBootstrapServers("localhost:9092")
         .withGroupId(group1)
         .withClientId(client1)
         .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
 
       val committedElement = new AtomicInteger(0)
-      val (control, probe1) = Consumer.committableSource(consumerSettings)
+      val (control, probe1) = Consumer.committableSource(consumerSettings, TopicSubscription(Set(topic1)))
         .filterNot(_.value == InitialMsg)
         .mapAsync(10) { elem =>
           elem.committableOffset.commitScaladsl().map { _ =>
@@ -129,7 +130,7 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
       probe1.cancel()
       Await.result(control.isShutdown, remainingOrDefault)
 
-      val probe2 = Consumer.committableSource(consumerSettings)
+      val probe2 = Consumer.committableSource(consumerSettings, TopicSubscription(Set(topic1)))
         .map(_.value)
         .runWith(TestSink.probe)
 
@@ -160,13 +161,13 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
         .map(n => new ProducerRecord(topic1, partition0, null: Array[Byte], n.toString))
         .runWith(Producer.plainSink(producerSettings))
 
-      val consumerSettings = ConsumerSettings(system, new ByteArrayDeserializer, new StringDeserializer, Set(topic1))
-        .withBootstrapServers(bootstrapServers)
+      val consumerSettings = ConsumerSettings(system, new ByteArrayDeserializer, new StringDeserializer)
+        .withBootstrapServers("localhost:9092")
         .withGroupId(group1)
         .withClientId(client1)
         .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
 
-      val (control, probe1) = Consumer.committableSource(consumerSettings)
+      val (control, probe1) = Consumer.committableSource(consumerSettings, TopicSubscription(Set(topic1)))
         .filterNot(_.value == InitialMsg)
         .toMat(TestSink.probe)(Keep.both)
         .run()

--- a/core/src/test/scala/examples/ByPartitionExample.scala
+++ b/core/src/test/scala/examples/ByPartitionExample.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package examples
+
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+import akka.actor.ActorSystem
+import akka.kafka.scaladsl.Consumer
+import akka.kafka.{ConsumerSettings, Subscriptions}
+import akka.stream.scaladsl.{Keep, Sink}
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}
+
+object ByPartitionExample extends App {
+  implicit val as = ActorSystem()
+  implicit val ec = as.dispatcher
+  implicit val m = ActorMaterializer(ActorMaterializerSettings(as).withInputBuffer(1, 1))
+
+  val settings = ConsumerSettings
+    .create(as, new ByteArrayDeserializer, new StringDeserializer)
+    .withBootstrapServers("kafka.host")
+    .withClientId(System.currentTimeMillis().toString)
+    .withGroupId("test1")
+
+  val (control, f) = Consumer.committablePartitionedSource(settings, Subscriptions.topics("topic1"))
+    .map {
+      case (tp, s) =>
+        println(s"Starting - $tp")
+        s.map { msg =>
+          val tp = msg.committableOffset.partitionOffset.key
+          println(s"Got message - ${tp.topic}, ${tp.partition}, ${msg.value}")
+          Thread.sleep(100)
+          msg
+        }
+          .mapAsync(1)(_.committableOffset.commitScaladsl())
+          .toMat(Sink.ignore)(Keep.right)
+          .mapMaterializedValue((tp, _))
+          .run()
+    }
+    .map { case (tp, completion) => completion.onComplete(result => println(s"$tp finished with $result")); tp }
+    .toMat(Sink.ignore)(Keep.both)
+    .run()
+
+  f.onComplete(x => println(x))
+  Thread.sleep(1000000)
+  control.shutdown()
+
+}

--- a/core/src/test/scala/examples/UsualSourceExample.scala
+++ b/core/src/test/scala/examples/UsualSourceExample.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package examples
+
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+import akka.actor.ActorSystem
+import akka.kafka.ConsumerMessage.CommittableOffsetBatch
+import akka.kafka.scaladsl.Consumer
+import akka.kafka.{ConsumerSettings, Subscriptions}
+import akka.stream.scaladsl.{Keep, Sink}
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
+import org.apache.kafka.common.serialization.{LongDeserializer, StringDeserializer}
+
+import scala.util.{Failure, Success}
+
+object UsualSourceExample extends App {
+  implicit val as = ActorSystem()
+  implicit val ec = as.dispatcher
+  implicit val m = ActorMaterializer(ActorMaterializerSettings(as).withInputBuffer(1, 1))
+
+  val settings = ConsumerSettings
+    .create(as, new LongDeserializer, new StringDeserializer)
+    .withBootstrapServers("k1.c.test:9092")
+    .withClientId(System.currentTimeMillis().toString)
+    .withGroupId("test1")
+
+  val (control, f) = Consumer.committableSource[java.lang.Long, String](settings, Subscriptions.topics("topic1"))
+    .map { x => println(x.committableOffset.partitionOffset.offset); Thread.sleep(1000); x }
+    .batch(max = 5, first => CommittableOffsetBatch.empty.updated(first.committableOffset)) { (batch, elem) =>
+      batch.updated(elem.committableOffset)
+    }
+    .mapAsync(1)(x => x.commitScaladsl())
+    .toMat(Sink.ignore)(Keep.both)
+    .run()
+
+  f.onComplete({
+    case Success(x) => println(x)
+    case Failure(ex) => ex.printStackTrace()
+  })
+  Thread.sleep(10000)
+  control.stop()
+  Thread.sleep(5000)
+  control.shutdown()
+
+}


### PR DESCRIPTION
This PR is implementations of `TopicPartitionSource`  - `Source[(TopicPartition, Source[Message])]`.

There is some small stuff to do, but I want to your feedback on the implementation.

Occasionally I reimplement all current consumer sources. I did it because the 0.11.M1 implementation contains several design problems:
- Strong coupling between stage and kafka consumer. With this coupling, it is very hard to reuse one kafka consumer from multiple (sub)sources.
- A complete mess in the `CommittableConsumer`. Patrik tried to extract some reusable stuff into a `GraphStageLogic`, but it is still the mess of lifecycle control, poll scheduling and other stuff.

My initial thought was `TopicPartitionSource` implementation on the top of the `GraphStage` as we did with `PlainSource` and `CommittableSource`. After quick prototyping, I figured out that hiding kafka consumer behind the `GraphStageLogic` and accessing it via callbacks producing very much boilerplate. I extract kafka consumer with all scheduling stuff and provide an asynchronous interface via `Future`s, but such interface produces a lot of boilerplate in `GraphStageLogic` too. So I decide to move away from `GraphStage` to `ActorPublisher` to be able to communicate with kafka consumer in an asynchronous way.

Another challenge is how to provide commit support on top of `PlainSource` without exposing much from it. Having kafka consumer decoupled from stage allows us to pass it to the `CommittableMessage` and build `CommittableMessage` on to of any `ConsumerMessage`.

What we have now:
- `KafkaConsumerActor` as a low-level abstraction on the top of KafkaConsumer
- `PlainSource`, `CommittableSource` and `TopicPatitionSource` implemented with `KafkaConsumerActor`
- `MessageBuilder` trait with `PlainMessageBuilder` and `CommittableMessageBuilder` implementations.

Feel free to comment the idea and the implementation.
