### PR TITLE
fix imports in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.softwaremill.react.kafka.KafkaMessages._
 import org.apache.kafka.common.serialization.{StringSerializer, StringDeserializer}
-import com.softwaremill.react.kafka.{ConsumerProperties, ProducerProperties, ReactiveKafka}
+import com.softwaremill.react.kafka.{ProducerMessage, ConsumerProperties, ProducerProperties, ReactiveKafka}
 import org.reactivestreams.{ Publisher, Subscriber }
 
 implicit val actorSystem = ActorSystem("ReactiveKafka")


### PR DESCRIPTION
`ProducerMessage` is used but not imported in this example. This PR adds it. Trivial fix, but should improve user's first experience w/ the library