### PR TITLE
add javadsl, #126

### DIFF
--- a/core/src/main/scala/akka/kafka/PartitionOffset.scala
+++ b/core/src/main/scala/akka/kafka/PartitionOffset.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.kafka
+
+/**
+ * Offset position for a clientId, topic, partition.
+ */
+final case class PartitionOffset(key: ClientTopicPartition, offset: Long)
+
+/**
+ * clientId, topic, partition key for an offset position.
+ */
+final case class ClientTopicPartition(
+  clientId: String,
+  topic: String,
+  partition: Int
+)

--- a/core/src/main/scala/akka/kafka/internal/Wrapped.scala
+++ b/core/src/main/scala/akka/kafka/internal/Wrapped.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.kafka.internal
+
+import java.util.concurrent.CompletionStage
+import scala.compat.java8.FutureConverters.FutureOps
+import scala.compat.java8.OptionConverters._
+import akka.Done
+import akka.kafka.javadsl
+import akka.kafka.scaladsl
+import akka.kafka.PartitionOffset
+import akka.kafka.ClientTopicPartition
+import java.util.Optional
+
+/**
+ * INTERNAL API
+ */
+private[kafka] class WrappedConsumerControl(underlying: scaladsl.Consumer.Control) extends javadsl.Consumer.Control {
+  override def stop(): CompletionStage[Done] = underlying.stop().toJava
+
+  override def shutdown(): CompletionStage[Done] = underlying.shutdown().toJava
+
+  override def isShutdown: CompletionStage[Done] = underlying.isShutdown.toJava
+}
+
+/**
+ * INTERNAL API
+ */
+private[kafka] class WrappedCommittableMessage[K, V](underlying: scaladsl.Consumer.CommittableMessage[K, V])
+    extends javadsl.Consumer.CommittableMessage[K, V] {
+
+  override def key: K = underlying.key
+
+  override def value: V = underlying.value
+
+  override val committableOffset: javadsl.Consumer.CommittableOffset =
+    new WrappedCommittableOffset(underlying.committableOffset)
+
+  override def partitionOffset: PartitionOffset = committableOffset.partitionOffset
+}
+
+/**
+ * INTERNAL API
+ */
+private[kafka] class WrappedCommittableOffset(val underlying: scaladsl.Consumer.CommittableOffset)
+    extends javadsl.Consumer.CommittableOffset {
+
+  override def partitionOffset: PartitionOffset = underlying.partitionOffset
+
+  override def commit(): CompletionStage[Done] = underlying.commit().toJava
+}
+
+/**
+ * INTERNAL API
+ */
+private[kafka] class WrappedConsumerMessage[K, V](underlying: scaladsl.Consumer.Message[K, V])
+    extends javadsl.Consumer.Message[K, V] {
+
+  override def key: K = underlying.key
+
+  override def value: V = underlying.value
+
+  override def partitionOffset: PartitionOffset = underlying.partitionOffset
+}
+
+/**
+ * INTERNAL API
+ */
+private[kafka] class WrappedCommittableOffsetBatch(underlying: scaladsl.Consumer.CommittableOffsetBatch)
+    extends javadsl.Consumer.CommittableOffsetBatch {
+
+  override def updated(offset: javadsl.Consumer.CommittableOffset): javadsl.Consumer.CommittableOffsetBatch =
+    offset match {
+      case w: WrappedCommittableOffset => new WrappedCommittableOffsetBatch(underlying.updated(w.underlying))
+      case other => throw new IllegalArgumentException("Unknown CommittableOffset implementation")
+    }
+
+  override def getOffset(key: ClientTopicPartition): Optional[Long] =
+    underlying.getOffset(key).asJava
+
+  override def commit(): CompletionStage[Done] = underlying.commit().toJava
+}
+
+/**
+ * INTERNAL API
+ */
+private[kafka] class WrappedProducerResult[K, V, PassThrough](underlying: scaladsl.Producer.Result[K, V, PassThrough])
+    extends javadsl.Producer.Result[K, V, PassThrough] {
+
+  override def offset: Long = underlying.offset
+
+  override def message: javadsl.Producer.Message[K, V, PassThrough] =
+    new javadsl.Producer.Message(underlying.message.record, underlying.message.passThrough)
+
+}

--- a/core/src/main/scala/akka/kafka/javadsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Producer.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.kafka.javadsl
+
+import akka.kafka.scaladsl
+import akka.NotUsed
+import akka.kafka.ProducerSettings
+import akka.kafka.internal.ProducerStage
+import akka.stream.javadsl.Flow
+import akka.stream.javadsl.Keep
+import akka.stream.javadsl.Sink
+import org.apache.kafka.clients.producer.ProducerRecord
+import akka.stream.ActorAttributes
+import akka.kafka.internal.WrappedProducerResult
+import akka.Done
+import java.util.concurrent.CompletionStage
+
+/**
+ * Akka Stream connector for publishing messages to Kafka topics.
+ */
+object Producer {
+
+  /**
+   * Input element of [[#commitableSink]] and [[#flow]].
+   *
+   * The `record` contains a topic name to which the record is being sent, an optional
+   * partition number, and an optional key and value.
+   *
+   * The `passThrough` field may hold any element that is passed through the [[#flow]]
+   * and included in the [[Result]]. That is useful when some context is needed to be passed
+   * on downstream operations. That could be done with unzip/zip, but this is more convenient.
+   * It can for example be a [[Consumer.CommittableOffset]] or [[Consumer.CommittableOffsetBatch]]
+   * that can be committed later in the flow.
+   */
+  final case class Message[K, V, +PassThrough](
+    record: ProducerRecord[K, V],
+    passThrough: PassThrough
+  )
+
+  /**
+   * Output element of [[#flow]]. Emitted when the message has been
+   * successfully published. Includes the original message and the
+   * `offset` of the produced message.
+   */
+  trait Result[K, V, PassThrough] {
+    def offset: Long
+    def message: Message[K, V, PassThrough]
+  }
+
+  /**
+   * The `plainSink` can be used for publishing records to Kafka topics.
+   * The `record` contains a topic name to which the record is being sent, an optional
+   * partition number, and an optional key and value.
+   */
+  def plainSink[K, V](settings: ProducerSettings[K, V]): Sink[ProducerRecord[K, V], NotUsed] =
+    scaladsl.Producer.plainSink(settings).asJava
+
+  /**
+   * Sink that is aware of the [[Consumer#CommittableOffset committable offset]]
+   * from a [[Consumer]]. It will commit the consumer offset when the message has
+   * been published successfully to the topic.
+   *
+   * Note that there is always a risk that something fails after publishing but before
+   * committing, so it is "at-least once delivery" semantics.
+   */
+  def commitableSink[K, V](settings: ProducerSettings[K, V]): Sink[Message[K, V, Consumer.Committable], NotUsed] = {
+    val commitFunction = new akka.japi.function.Function[Result[K, V, Consumer.Committable], CompletionStage[Done]] {
+      override def apply(c: Result[K, V, Consumer.Committable]): CompletionStage[Done] = c.message.passThrough.commit()
+    }
+    flow[K, V, Consumer.Committable](settings)
+      .mapAsync(settings.parallelism, commitFunction)
+      .to(Sink.ignore())
+  }
+
+  /**
+   * Publish records to Kafka topics and then continue the flow. Possibility to pass through a message, which
+   * can for example be a [[Consumer.CommittableOffset]] or [[Consumer.CommittableOffsetBatch]] that can
+   * be committed later in the flow.
+   */
+  def flow[K, V, PassThrough](settings: ProducerSettings[K, V]): Flow[Message[K, V, PassThrough], Result[K, V, PassThrough], NotUsed] =
+    akka.stream.scaladsl.Flow[Message[K, V, PassThrough]]
+      .map(m => scaladsl.Producer.Message(m.record, m.passThrough))
+      .via(scaladsl.Producer.flow(settings))
+      .map(new WrappedProducerResult(_))
+      .asJava
+
+}
+

--- a/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
@@ -5,12 +5,11 @@
 package akka.kafka.internal
 
 import java.util.{Map => JMap}
-
 import akka.Done
 import akka.actor.ActorSystem
 import akka.kafka.ConsumerSettings
 import akka.kafka.scaladsl.Consumer
-import akka.kafka.scaladsl.Consumer.{ClientTopicPartition, CommittableMessage, CommittableOffsetBatch, Control}
+import akka.kafka.scaladsl.Consumer.{CommittableMessage, CommittableOffsetBatch, Control}
 import akka.stream._
 import akka.stream.scaladsl._
 import akka.stream.testkit.scaladsl.TestSink
@@ -25,11 +24,12 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.mockito.verification.VerificationMode
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
-
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
+import akka.kafka.ClientTopicPartition
+import akka.kafka.PartitionOffset
 
 object ConsumerTest {
   type K = String
@@ -39,7 +39,7 @@ object ConsumerTest {
   def createMessage(seed: Int): Consumer.CommittableMessage[K, V] = createMessage(seed, "topic")
 
   def createMessage(seed: Int, topic: String, clientId: String = "client1"): Consumer.CommittableMessage[K, V] = {
-    val offset = Consumer.PartitionOffset(ClientTopicPartition(clientId, topic, 1), seed.toLong)
+    val offset = PartitionOffset(ClientTopicPartition(clientId, topic, 1), seed.toLong)
     Consumer.CommittableMessage(seed.toString, seed.toString, ConsumerStage.CommittableOffsetImpl(offset)(null))
   }
 


### PR DESCRIPTION
Here is a first stab at the javadsl where I have taken the wrapping approach.

It's rather messy. The alternative is to put the "message" classes outside of dsl package and provide both java and scala api in them. The methods that require different signatures are:
```
def commit(): CompletionStage[Done]
def getOffset(key: ClientTopicPartition): Optional[Long]
```

I'm not sure which approach is best here.

I will also convert the examples (readme) and write some smoke tests.