### PR TITLE
Expose kafka message

### DIFF
--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletionStage
 
 import akka.Done
 import akka.kafka.internal.ConsumerStage.CommittableOffsetBatchImpl
+import org.apache.kafka.clients.consumer.ConsumerRecord
 
 import scala.concurrent.Future
 
@@ -17,28 +18,14 @@ import scala.concurrent.Future
  * [[scaladsl.Consumer]].
  */
 object ConsumerMessage {
-
-  /**
-   * Output element of `atMostOnceSource`.
-   */
-  trait Message[K, V] {
-    def key: K
-    def value: V
-    def partitionOffset: PartitionOffset
-  }
-
   /**
    * Output element of `committableSource`.
    * The offset can be committed via the included [[CommittableOffset]].
    */
   final case class CommittableMessage[K, V](
-      key: K,
-      value: V,
+      record: ConsumerRecord[K, V],
       committableOffset: CommittableOffset
-  ) extends Message[K, V] {
-
-    override def partitionOffset: PartitionOffset = committableOffset.partitionOffset
-  }
+  )
 
   /**
    * Commit an offset that is included in a [[CommittableMessage]].

--- a/core/src/main/scala/akka/kafka/internal/ConsumerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ConsumerStage.scala
@@ -135,7 +135,7 @@ private[kafka] object ConsumerStage {
         ),
         offset = rec.offset
       )
-      ConsumerMessage.CommittableMessage(rec.key, rec.value, CommittableOffsetImpl(offset)(committer))
+      ConsumerMessage.CommittableMessage(rec, CommittableOffsetImpl(offset)(committer))
     }
   }
 

--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletionStage
 
 import akka.actor.ActorRef
 import akka.japi.Pair
-import akka.kafka.ConsumerMessage.{CommittableMessage, Message}
+import akka.kafka.ConsumerMessage.CommittableMessage
 import akka.kafka.internal.ConsumerStage.WrappedConsumerControl
 import akka.kafka.{AutoSubscription, ConsumerSettings, ManualSubscription, Subscription, scaladsl}
 import akka.stream.javadsl.Source
@@ -88,7 +88,7 @@ object Consumer {
    * Convenience for "at-most once delivery" semantics. The offset of each message is committed to Kafka
    * before emitted downstreams.
    */
-  def atMostOnceSource[K, V](settings: ConsumerSettings[K, V], subscription: Subscription): Source[Message[K, V], Control] =
+  def atMostOnceSource[K, V](settings: ConsumerSettings[K, V], subscription: Subscription): Source[ConsumerRecord[K, V], Control] =
     scaladsl.Consumer.atMostOnceSource(settings, subscription)
       .mapMaterializedValue(new WrappedConsumerControl(_))
       .asJava

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -6,7 +6,7 @@ package akka.kafka.scaladsl
 
 import akka.actor.ActorRef
 import akka.dispatch.ExecutionContexts
-import akka.kafka.ConsumerMessage.{CommittableMessage, Message}
+import akka.kafka.ConsumerMessage.CommittableMessage
 import akka.kafka.internal.ConsumerStage
 import akka.kafka.{AutoSubscription, ConsumerSettings, ManualSubscription, Subscription}
 import akka.stream.ActorAttributes
@@ -90,9 +90,9 @@ object Consumer {
    * Convenience for "at-most once delivery" semantics. The offset of each message is committed to Kafka
    * before emitted downstreams.
    */
-  def atMostOnceSource[K, V](settings: ConsumerSettings[K, V], subscription: Subscription): Source[Message[K, V], Control] = {
+  def atMostOnceSource[K, V](settings: ConsumerSettings[K, V], subscription: Subscription): Source[ConsumerRecord[K, V], Control] = {
     committableSource[K, V](settings, subscription).mapAsync(1) { m =>
-      m.committableOffset.commitScaladsl().map(_ => m)(ExecutionContexts.sameThreadExecutionContext)
+      m.committableOffset.commitScaladsl().map(_ => m.record)(ExecutionContexts.sameThreadExecutionContext)
     }
   }
 

--- a/core/src/test/scala/examples/ByPartitionExample.scala
+++ b/core/src/test/scala/examples/ByPartitionExample.scala
@@ -32,7 +32,7 @@ object ByPartitionExample extends App {
         println(s"Starting - $tp")
         s.map { msg =>
           val tp = msg.committableOffset.partitionOffset.key
-          println(s"Got message - ${tp.topic}, ${tp.partition}, ${msg.value}")
+          println(s"Got message - ${tp.topic}, ${tp.partition}, ${msg.record.value}")
           Thread.sleep(100)
           msg
         }

--- a/core/src/test/scala/examples/scaladsl/ConsumerExample.scala
+++ b/core/src/test/scala/examples/scaladsl/ConsumerExample.scala
@@ -74,7 +74,7 @@ object AtLeastOnceExample extends ConsumerExample {
 
   Consumer.committableSource(consumerSettings.withClientId("client1"), Subscriptions.topics("topic1"))
     .mapAsync(1) { msg =>
-      db.update(msg.value).flatMap(_ => msg.committableOffset.commitScaladsl())
+      db.update(msg.record.value).flatMap(_ => msg.committableOffset.commitScaladsl())
     }
 }
 
@@ -84,7 +84,7 @@ object AtLeastOnceWithBatchCommitExample extends ConsumerExample {
 
   Consumer.committableSource(consumerSettings.withClientId("client1"), Subscriptions.topics("topic1"))
     .mapAsync(1) { msg =>
-      db.update(msg.value).map(_ => msg.committableOffset)
+      db.update(msg.record.value).map(_ => msg.committableOffset)
     }
     .batch(max = 10, first => CommittableOffsetBatch.empty.updated(first)) { (batch, elem) =>
       batch.updated(elem)
@@ -96,7 +96,7 @@ object AtLeastOnceWithBatchCommitExample extends ConsumerExample {
 object ConsumerToProducerSinkExample extends ConsumerExample {
   Consumer.committableSource(consumerSettings.withClientId("client1"), Subscriptions.topics("topic1"))
     .map(msg =>
-      ProducerMessage.Message(new ProducerRecord[Array[Byte], String]("topic2", msg.value), msg.committableOffset))
+      ProducerMessage.Message(new ProducerRecord[Array[Byte], String]("topic2", msg.record.value), msg.committableOffset))
     .to(Producer.commitableSink(producerSettings))
 }
 
@@ -104,7 +104,7 @@ object ConsumerToProducerSinkExample extends ConsumerExample {
 object ConsumerToProducerFlowExample extends ConsumerExample {
   Consumer.committableSource(consumerSettings.withClientId("client1"), Subscriptions.topics("topic1"))
     .map(msg =>
-      ProducerMessage.Message(new ProducerRecord[Array[Byte], String]("topic2", msg.value), msg.committableOffset))
+      ProducerMessage.Message(new ProducerRecord[Array[Byte], String]("topic2", msg.record.value), msg.committableOffset))
     .via(Producer.flow(producerSettings))
     .mapAsync(producerSettings.parallelism) { result => result.message.passThrough.commitScaladsl() }
 }
@@ -113,7 +113,7 @@ object ConsumerToProducerFlowExample extends ConsumerExample {
 object ConsumerToProducerWithBatchCommitsExample extends ConsumerExample {
   Consumer.committableSource(consumerSettings.withClientId("client1"), Subscriptions.topics("topic1"))
     .map(msg =>
-      ProducerMessage.Message(new ProducerRecord[Array[Byte], String]("topic2", msg.value), msg.committableOffset))
+      ProducerMessage.Message(new ProducerRecord[Array[Byte], String]("topic2", msg.record.value), msg.committableOffset))
     .via(Producer.flow(producerSettings))
     .map(_.message.passThrough)
     .batch(max = 10, first => CommittableOffsetBatch.empty.updated(first)) { (batch, elem) =>
@@ -126,7 +126,7 @@ object ConsumerToProducerWithBatchCommitsExample extends ConsumerExample {
 object ConsumerToProducerWithBatchCommits2Example extends ConsumerExample {
   Consumer.committableSource(consumerSettings.withClientId("client1"), Subscriptions.topics("topic1"))
     .map(msg =>
-      ProducerMessage.Message(new ProducerRecord[Array[Byte], String]("topic2", msg.value), msg.committableOffset))
+      ProducerMessage.Message(new ProducerRecord[Array[Byte], String]("topic2", msg.record.value), msg.committableOffset))
     .via(Producer.flow(producerSettings))
     .map(_.message.passThrough)
     .groupedWithin(10, 5.seconds)


### PR DESCRIPTION
The idea here is to expose raw kafka message and not fields inside of it. I see no reason to hide this message from end user. Also we reduce amount of useless objects to create. 

Any ideas why we should keep kafka messages hidden from end-user?