### PR TITLE
Reusable producer

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -4,17 +4,11 @@
 # the same layout. 
 akka.kafka.producer {
   # Tuning parameter of how many sends that can run in parallel.
-  parallelism = 5
+  parallelism = 100
   
   # How long to wait for `KafkaProducer.close`
   close-timeout = 60s
   
-  # Fully qualified config path which holds the dispatcher configuration
-  # to be used by the producer stages. Some blocking may occur.
-  # When this value is empty, the dispatcher configured for the stream
-  # will be used.
-  use-dispatcher = "akka.kafka.default-dispatcher"
-
   # Properties defined by org.apache.kafka.clients.producer.ProducerConfig
   # can be defined in this configuration section.
   kafka-clients {

--- a/core/src/main/scala/akka/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ProducerSettings.scala
@@ -71,8 +71,7 @@ object ProducerSettings {
     )
     val closeTimeout = config.getDuration("close-timeout", TimeUnit.MILLISECONDS).millis
     val parallelism = config.getInt("parallelism")
-    val dispatcher = config.getString("use-dispatcher")
-    new ProducerSettings[K, V](properties, keySerializer, valueSerializer, closeTimeout, parallelism, dispatcher)
+    new ProducerSettings[K, V](properties, keySerializer, valueSerializer, closeTimeout, parallelism)
   }
 
   /**
@@ -155,8 +154,7 @@ final class ProducerSettings[K, V](
     val keySerializerOpt: Option[Serializer[K]],
     val valueSerializerOpt: Option[Serializer[V]],
     val closeTimeout: FiniteDuration,
-    val parallelism: Int,
-    val dispatcher: String
+    val parallelism: Int
 ) {
 
   def withBootstrapServers(bootstrapServers: String): ProducerSettings[K, V] =
@@ -175,18 +173,14 @@ final class ProducerSettings[K, V](
   def withParallelism(parallelism: Int): ProducerSettings[K, V] =
     copy(parallelism = parallelism)
 
-  def withDispatcher(dispatcher: String): ProducerSettings[K, V] =
-    copy(dispatcher = dispatcher)
-
   private def copy(
     properties: Map[String, String] = properties,
     keySerializer: Option[Serializer[K]] = keySerializerOpt,
     valueSerializer: Option[Serializer[V]] = valueSerializerOpt,
     closeTimeout: FiniteDuration = closeTimeout,
-    parallelism: Int = parallelism,
-    dispatcher: String = dispatcher
+    parallelism: Int = parallelism
   ): ProducerSettings[K, V] =
-    new ProducerSettings[K, V](properties, keySerializer, valueSerializer, closeTimeout, parallelism, dispatcher)
+    new ProducerSettings[K, V](properties, keySerializer, valueSerializer, closeTimeout, parallelism)
 
   /**
    * Create a `KafkaProducer` instance from the settings.

--- a/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
@@ -4,16 +4,15 @@
  */
 package akka.kafka.scaladsl
 
-import scala.concurrent.Future
-
-import akka.Done
-import akka.NotUsed
-import akka.kafka.{ConsumerMessage, ProducerSettings}
 import akka.kafka.ProducerMessage._
 import akka.kafka.internal.ProducerStage
-import akka.stream.ActorAttributes
+import akka.kafka.{ConsumerMessage, ProducerSettings}
 import akka.stream.scaladsl.{Flow, Keep, Sink}
-import org.apache.kafka.clients.producer.ProducerRecord
+import akka.{Done, NotUsed}
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * Akka Stream connector for publishing messages to Kafka topics.
@@ -26,8 +25,20 @@ object Producer {
    * partition number, and an optional key and value.
    */
   def plainSink[K, V](settings: ProducerSettings[K, V]): Sink[ProducerRecord[K, V], Future[Done]] =
+    plainSink(() => settings.createKafkaProducer(), settings.closeTimeout, settings.parallelism)
+
+  /**
+   * The `plainSink` can be used for publishing records to Kafka topics.
+   * The `record` contains a topic name to which the record is being sent, an optional
+   * partition number, and an optional key and value.
+   */
+  def plainSink[K, V](
+    producerProvider: () => KafkaProducer[K, V],
+    closeTimeout: FiniteDuration,
+    parallelism: Int
+  ): Sink[ProducerRecord[K, V], Future[Done]] =
     Flow[ProducerRecord[K, V]].map(record => Message(record, NotUsed))
-      .via(flow(settings))
+      .via(flow(producerProvider, closeTimeout, parallelism))
       .toMat(Sink.ignore)(Keep.right)
 
   /**
@@ -39,8 +50,23 @@ object Producer {
    * committing, so it is "at-least once delivery" semantics.
    */
   def commitableSink[K, V](settings: ProducerSettings[K, V]): Sink[Message[K, V, ConsumerMessage.Committable], Future[Done]] =
-    flow[K, V, ConsumerMessage.Committable](settings)
-      .mapAsync(settings.parallelism)(_.message.passThrough.commitScaladsl())
+    commitableSink(() => settings.createKafkaProducer(), settings.closeTimeout, settings.parallelism)
+
+  /**
+   * Sink that is aware of the [[ConsumerMessage#CommittableOffset committable offset]]
+   * from a [[Consumer]]. It will commit the consumer offset when the message has
+   * been published successfully to the topic.
+   *
+   * Note that there is always a risk that something fails after publishing but before
+   * committing, so it is "at-least once delivery" semantics.
+   */
+  def commitableSink[K, V](
+    producerProvider: () => KafkaProducer[K, V],
+    closeTimeout: FiniteDuration,
+    parallelism: Int
+  ): Sink[Message[K, V, ConsumerMessage.Committable], Future[Done]] =
+    flow[K, V, ConsumerMessage.Committable](producerProvider, closeTimeout, parallelism)
+      .mapAsync(parallelism)(_.message.passThrough.commitScaladsl())
       .toMat(Sink.ignore)(Keep.right)
 
   /**
@@ -49,10 +75,23 @@ object Producer {
    * be committed later in the flow.
    */
   def flow[K, V, PassThrough](settings: ProducerSettings[K, V]): Flow[Message[K, V, PassThrough], Result[K, V, PassThrough], NotUsed] = {
+    flow(() => settings.createKafkaProducer(), settings.closeTimeout, settings.parallelism)
+  }
+
+  /**
+   * Publish records to Kafka topics and then continue the flow. Possibility to pass through a message, which
+   * can for example be a [[ConsumerMessage.CommittableOffset]] or [[ConsumerMessage.CommittableOffsetBatch]] that can
+   * be committed later in the flow.
+   */
+  def flow[K, V, PassThrough](
+    producerProvider: () => KafkaProducer[K, V],
+    closeTimeout: FiniteDuration,
+    parallelism: Int
+  ): Flow[Message[K, V, PassThrough], Result[K, V, PassThrough], NotUsed] = {
     Flow.fromGraph(new ProducerStage[K, V, PassThrough](
-      closeTimeout = settings.closeTimeout,
-      () => settings.createKafkaProducer()
-    )).mapAsync(settings.parallelism)(identity)
+      closeTimeout = closeTimeout,
+      producerProvider = producerProvider
+    )).mapAsync(parallelism)(identity)
   }
 
 }

--- a/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
@@ -49,13 +49,10 @@ object Producer {
    * be committed later in the flow.
    */
   def flow[K, V, PassThrough](settings: ProducerSettings[K, V]): Flow[Message[K, V, PassThrough], Result[K, V, PassThrough], NotUsed] = {
-    val flow = Flow.fromGraph(new ProducerStage[K, V, PassThrough](
-      settings,
+    Flow.fromGraph(new ProducerStage[K, V, PassThrough](
+      closeTimeout = settings.closeTimeout,
       () => settings.createKafkaProducer()
-    ))
-      .mapAsync(settings.parallelism)(identity)
-    if (settings.dispatcher.isEmpty) flow
-    else flow.withAttributes(ActorAttributes.dispatcher(settings.dispatcher))
+    )).mapAsync(settings.parallelism)(identity)
   }
 
 }

--- a/core/src/test/scala/akka/kafka/internal/ProducerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ProducerTest.scala
@@ -65,7 +65,7 @@ class ProducerTest(_system: ActorSystem)
   val settings = ProducerSettings(system, new StringSerializer, new StringSerializer)
 
   def testProducerFlow[P](mock: ProducerMock[K, V]): Flow[Message[K, V, P], Result[K, V, P], NotUsed] =
-    Flow.fromGraph(new ProducerStage[K, V, P](settings, () => mock.mock))
+    Flow.fromGraph(new ProducerStage[K, V, P](settings.closeTimeout, () => mock.mock))
       .mapAsync(1)(identity)
 
   "Producer" should "not send messages when source is empty" in {


### PR DESCRIPTION
Implements https://github.com/akka/reactive-kafka/issues/154

Also I removed dispatcher for producer because producer's API is non-blocking.