### PR TITLE
Producer benchmarks

### DIFF
--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/KafkaProducerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/KafkaProducerBenchmarks.scala
@@ -17,7 +17,7 @@ object KafkaProducerBenchmarks extends LazyLogging {
    */
   def plainFlow(fixture: KafkaProducerTestFixture, meter: Meter): Unit = {
     val producer = fixture.producer
-    var lastPartStart = System.nanoTime()
+    @volatile var lastPartStart = System.nanoTime()
 
     for (i <- 1 to fixture.msgCount) {
       producer.send(new ProducerRecord[Array[Byte], String](fixture.topic, i.toString))

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/KafkaProducerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/KafkaProducerBenchmarks.scala
@@ -7,18 +7,27 @@ package akka.kafka.benchmarks
 import com.codahale.metrics.Meter
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.clients.producer.ProducerRecord
+import scala.concurrent.duration._
 
 object KafkaProducerBenchmarks extends LazyLogging {
 
+  val logStep = 100000
   /**
    * Streams generated numbers to a Kafka producer. Does not commit.
    */
   def plainFlow(fixture: KafkaProducerTestFixture, meter: Meter): Unit = {
     val producer = fixture.producer
+    var lastPartStart = System.nanoTime()
 
     for (i <- 1 to fixture.msgCount) {
       producer.send(new ProducerRecord[Array[Byte], String](fixture.topic, i.toString))
       meter.mark()
+      if (i % logStep == 0) {
+        val lastPartEnd = System.nanoTime()
+        val took = (lastPartEnd - lastPartStart).nanos
+        logger.info(s"Sent $i, took ${took.toMillis} ms to send last $logStep")
+        lastPartStart = lastPartEnd
+      }
     }
     fixture.close()
   }

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/KafkaProducerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/KafkaProducerBenchmarks.scala
@@ -6,15 +6,9 @@ package akka.kafka.benchmarks
 
 import com.codahale.metrics.Meter
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.apache.kafka.common.TopicPartition
-
-import scala.annotation.tailrec
-import scala.collection.JavaConversions._
 
 object KafkaProducerBenchmarks extends LazyLogging {
-  val pollTimeoutMs = 50L
 
   /**
    * Streams generated numbers to a Kafka producer. Does not commit.

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/KafkaProducerFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/KafkaProducerFixtureGen.scala
@@ -5,11 +5,7 @@
 package akka.kafka.benchmarks
 
 import akka.kafka.benchmarks.app.RunTestCommand
-import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.clients.producer.KafkaProducer
-import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}
-
-import scala.collection.JavaConversions._
 
 case class KafkaProducerTestFixture(topic: String, msgCount: Int, producer: KafkaProducer[Array[Byte], String]) {
   def close(): Unit = producer.close()

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/PerfFixtureHelpers.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/PerfFixtureHelpers.scala
@@ -29,7 +29,7 @@ private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
     producerJavaProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHost)
     val producer = new KafkaProducer[Array[Byte], String](producerJavaProps, new ByteArraySerializer, new StringSerializer)
     val lastElementStoredPromise = Promise[Unit]
-    val loggedStep = if (msgCount >= logPercentStep) msgCount / (100 / logPercentStep) else 1
+    val loggedStep = if (msgCount > logPercentStep) msgCount / (100 / logPercentStep) else 1
     for (i <- 0L to msgCount.toLong) {
       if (!lastElementStoredPromise.isCompleted) {
         producer.send(new ProducerRecord[Array[Byte], String](topic, i.toString), new Callback {

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaProducerFixtures.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaProducerFixtures.scala
@@ -16,7 +16,7 @@ import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSeriali
 
 object ReactiveKafkaProducerFixtures extends PerfFixtureHelpers {
 
-  val Parallelism = 15
+  val Parallelism = 100
 
   type K = Array[Byte]
   type V = String

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/Timed.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/Timed.scala
@@ -11,6 +11,7 @@ import com.codahale.metrics.{Meter, MetricRegistry, ScheduledReporter, Slf4jRepo
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 object Timed extends LazyLogging {
 
@@ -35,7 +36,8 @@ object Timed extends LazyLogging {
     val now = System.nanoTime()
     testBody(fixture, meter)
     val after = System.nanoTime()
-    logger.info(s"Test ${name}_$msgCount took ${(after - now) / 1000000} ms")
+    val took = (after - now).nanos
+    logger.info(s"Test ${name}_$msgCount took ${took.toMillis} ms")
     reporter(metrics).report()
   }
 }


### PR DESCRIPTION
This PR finishes the producer benchmarks. Some initial test results:

plain-producer 308000 msg/s
akka-plain-producer 61000 msg/s

Tests performed with parallelism = 100.
I experimented with changing `mapAsync` in `Producer.flow` to `mapAsyncUnordered` but it didn't affect the results.