### PR TITLE
Fix test: consume and commit in batches

### DIFF
--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -248,7 +248,7 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
       val (control, probe) = consumeAndBatchCommit(topic1)
 
       // Request one batch
-      probe.request(1).expectNextN(1)
+      probe.request(5).expectNextN(1)
 
       probe.cancel()
       Await.result(control.isShutdown, remainingOrDefault)

--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -258,7 +258,7 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
         .runWith(TestSink.probe)
 
       val element = probe2.request(1).expectNext()
-
+      println("After first assertion")
       // Verify that consumption does not start from first element
       Assertions.assert(element.toInt > 1)
       probe2.cancel()

--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -241,7 +241,7 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
           .batch(max = 10, first => CommittableOffsetBatch.empty.updated(first)) {
             (batch, elem) => batch.updated(elem)
           }
-          .mapAsync(1)(_.commitScaladsl())
+          .mapAsync(1)( {println("commit batch"); _.commitScaladsl()})
           .toMat(TestSink.probe)(Keep.both).run()
       }
 

--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -257,6 +257,7 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
         .map(_.record.value)
         .runWith(TestSink.probe)
 
+      println("Before first assertion")
       val element = probe2.request(1).expectNext()
       println("After first assertion")
       // Verify that consumption does not start from first element

--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -29,6 +29,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer, StringDeserializer, StringSerializer}
 import org.scalactic.ConversionCheckedTripleEquals
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
+import org.scalatest.Assertions
 
 class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
     with WordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach
@@ -236,30 +237,31 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
 
       def consumeAndBatchCommit(topic: String) = {
         Consumer.committableSource(consumerSettings, TopicSubscription(Set(topic)))
-          .map { msg => { msg.committableOffset } }
-          .batch(max = 10, first => CommittableOffsetBatch.empty.updated(first)) { (batch, elem) =>
-            batch.updated(elem)
+          .map { msg => msg.committableOffset }
+          .batch(max = 10, first => CommittableOffsetBatch.empty.updated(first)) {
+            (batch, elem) => batch.updated(elem)
           }
-          .mapAsync(1)(_.commitScaladsl()).toMat(TestSink.probe)(Keep.both)
+          .mapAsync(1)(_.commitScaladsl())
+          .toMat(TestSink.probe)(Keep.both).run()
       }
 
-      consumeAndBatchCommit(topic1)
+      val (control, probe) = consumeAndBatchCommit(topic1)
 
-      val probe = createProbe(consumerSettings, topic1)
-
-      probe
-        .request(100)
-        .expectNextN((1 to 100).map(_.toString))
-
-      Await.result(produce(topic1, 101 to 150), remainingOrDefault)
-
-      consumeAndBatchCommit(topic1)
-
-      probe
-        .request(50)
-        .expectNextN((101 to 150).map(_.toString))
+      // Request one batch
+      probe.request(1).expectNextN(1)
 
       probe.cancel()
+      Await.result(control.isShutdown, remainingOrDefault)
+
+      val probe2 = Consumer.committableSource(consumerSettings, TopicSubscription(Set(topic1)))
+        .map(_.record.value)
+        .runWith(TestSink.probe)
+
+      val element = probe2.request(1).expectNext()
+
+      // Verify that consumption does not start from first element
+      Assertions.assert(element.toInt > 1)
+      probe2.cancel()
     }
 
     "connect consumer to producer and commit in batches" in {


### PR DESCRIPTION
Fix "consume and commit in batches", i.e. function `consumeAndBatchCommit`
does not materialize the stream.  Changes are

  * `consumeAndBatchCommit` now materializes the stream
  * Consume one batch
  * Cancel and resume consumption
  * Verify that consumption does not start from the first element

Note: I looked into using mutable	state as done in "resume consumer from committed offset"
to keep track of the most recent committed element.  However, at the point where `CommittableOffsetBatch.commitScaladsl` is called only the offsets are exposed.

The tests pass locally so I'll leave this PR open so I can debug the Travis build failure.

**Update**:  Haven't made any progress on identifying why test fails on Travis. 