### PR TITLE
Change to Option/Optional key/value serde in Consumer/Producer Settings

### DIFF
--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerFixtures.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerFixtures.scala
@@ -19,7 +19,7 @@ case class ReactiveKafkaConsumerTestFixture[T](topic: String, msgCount: Int, sou
 object ReactiveKafkaConsumerFixtures extends PerfFixtureHelpers {
 
   private def createConsumerSettings(kafkaHost: String)(implicit actorSystem: ActorSystem) =
-    ConsumerSettings(actorSystem, new ByteArrayDeserializer, new StringDeserializer)
+    ConsumerSettings(actorSystem, Some(new ByteArrayDeserializer), Some(new StringDeserializer))
       .withBootstrapServers(kafkaHost)
       .withGroupId(randomId())
       .withClientId(randomId())

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaProducerFixtures.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaProducerFixtures.scala
@@ -27,7 +27,7 @@ object ReactiveKafkaProducerFixtures extends PerfFixtureHelpers {
   case class ReactiveKafkaProducerTestFixture[PassThrough](topic: String, msgCount: Int, flow: FlowType[PassThrough])
 
   private def createProducerSettings(kafkaHost: String)(implicit actorSystem: ActorSystem): ProducerSettings[K, V] =
-    ProducerSettings(actorSystem, new ByteArraySerializer, new StringSerializer)
+    ProducerSettings(actorSystem, Some(new ByteArraySerializer), Some(new StringSerializer))
       .withBootstrapServers(kafkaHost)
       .withParallelism(Parallelism)
 

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -4,6 +4,7 @@
  */
 package akka.kafka
 
+import java.util.Optional
 import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystem
@@ -16,6 +17,7 @@ import org.apache.kafka.common.serialization.Deserializer
 import scala.annotation.varargs
 import scala.concurrent.duration._
 import scala.collection.JavaConverters._
+import scala.compat.java8.OptionConverters._
 
 sealed trait Subscription
 sealed trait ManualSubscription extends Subscription
@@ -95,9 +97,31 @@ object ConsumerSettings {
   /**
    * Create settings from the default configuration
    * `akka.kafka.consumer`.
+   * Key and value deserializer will be retrieved from configuration.
+   */
+  def apply[K, V](
+    system: ActorSystem
+  ): ConsumerSettings[K, V] = {
+    apply(system, None, None)
+  }
+
+  /**
+   * Create settings from a configuration with the same layout as
+   * the default configuration `akka.kafka.consumer`.
+   * Key and value deserializer will be retrieved from passed configuration.
+   */
+  def apply[K, V](
+    config: Config
+  ): ConsumerSettings[K, V] = {
+    apply(config, None, None)
+  }
+
+  /**
+   * Create settings from the default configuration
+   * `akka.kafka.consumer`.
    * Key or value deserializer can be passed explicitly or retrieved from configuration.
    */
-  private def apply[K, V](
+  def apply[K, V](
     system: ActorSystem,
     keyDeserializer: Option[Deserializer[K]],
     valueDeserializer: Option[Deserializer[V]]
@@ -111,7 +135,7 @@ object ConsumerSettings {
    * the default configuration `akka.kafka.consumer`.
    * Key or value deserializer can be passed explicitly or retrieved from configuration.
    */
-  private def apply[K, V](
+  def apply[K, V](
     config: Config,
     keyDeserializer: Option[Deserializer[K]],
     valueDeserializer: Option[Deserializer[V]]
@@ -136,52 +160,6 @@ object ConsumerSettings {
   }
 
   /**
-   * Create settings from the default configuration
-   * `akka.kafka.consumer`.
-   * Key and value deserializer will be retrieved from configuration.
-   */
-  def apply[K, V](
-    system: ActorSystem
-  ): ConsumerSettings[K, V] = {
-    apply(system, None, None)
-  }
-
-  /**
-   * Create settings from a configuration with the same layout as
-   * the default configuration `akka.kafka.consumer`.
-   * Key and value deserializer will be retrieved from passed configuration.
-   */
-  def apply[K, V](
-    config: Config
-  ): ConsumerSettings[K, V] = {
-    apply(config, None, None)
-  }
-
-  /**
-   * Create settings from the default configuration
-   * `akka.kafka.consumer`.
-   */
-  def apply[K, V](
-    system: ActorSystem,
-    keyDeserializer: Deserializer[K],
-    valueDeserializer: Deserializer[V]
-  ): ConsumerSettings[K, V] = {
-    apply(system, Some(keyDeserializer), Some(valueDeserializer))
-  }
-
-  /**
-   * Create settings from a configuration with the same layout as
-   * the default configuration `akka.kafka.consumer`.
-   */
-  def apply[K, V](
-    config: Config,
-    keyDeserializer: Deserializer[K],
-    valueDeserializer: Deserializer[V]
-  ): ConsumerSettings[K, V] = {
-    apply(config, Some(keyDeserializer), Some(valueDeserializer))
-  }
-
-  /**
    * Java API: Create settings from the default configuration
    * `akka.kafka.consumer`.
    * Key and value deserializer will be retrieved from configuration.
@@ -206,24 +184,26 @@ object ConsumerSettings {
   /**
    * Java API: Create settings from the default configuration
    * `akka.kafka.consumer`.
+   * Key or value deserializer can be passed explicitly or retrieved from configuration.
    */
   def create[K, V](
     system: ActorSystem,
-    keyDeserializer: Deserializer[K],
-    valueDeserializer: Deserializer[V]
+    keyDeserializer: Optional[Deserializer[K]],
+    valueDeserializer: Optional[Deserializer[V]]
   ): ConsumerSettings[K, V] =
-    apply(system, Option(keyDeserializer), Option(valueDeserializer))
+    apply(system, keyDeserializer.asScala, valueDeserializer.asScala)
 
   /**
    * Java API: Create settings from a configuration with the same layout as
    * the default configuration `akka.kafka.consumer`.
+   * Key or value deserializer can be passed explicitly or retrieved from configuration.
    */
   def create[K, V](
     config: Config,
-    keyDeserializer: Deserializer[K],
-    valueDeserializer: Deserializer[V]
+    keyDeserializer: Optional[Deserializer[K]],
+    valueDeserializer: Optional[Deserializer[V]]
   ): ConsumerSettings[K, V] =
-    apply(config, Option(keyDeserializer), Option(valueDeserializer))
+    apply(config, keyDeserializer.asScala, valueDeserializer.asScala)
 }
 
 /**

--- a/core/src/main/scala/akka/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ProducerSettings.scala
@@ -4,6 +4,7 @@
  */
 package akka.kafka
 
+import java.util.Optional
 import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystem
@@ -12,6 +13,7 @@ import com.typesafe.config.Config
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig}
 import org.apache.kafka.common.serialization.Serializer
 
+import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration._
 
 object ProducerSettings {
@@ -43,7 +45,7 @@ object ProducerSettings {
    * `akka.kafka.producer`.
    * Key or value serializer can be passed explicitly or retrieved from configuration.
    */
-  private def apply[K, V](
+  def apply[K, V](
     system: ActorSystem,
     keySerializer: Option[Serializer[K]],
     valueSerializer: Option[Serializer[V]]
@@ -55,7 +57,7 @@ object ProducerSettings {
    * the default configuration `akka.kafka.producer`.
    * Key or value serializer can be passed explicitly or retrieved from configuration.
    */
-  private def apply[K, V](
+  def apply[K, V](
     config: Config,
     keySerializer: Option[Serializer[K]],
     valueSerializer: Option[Serializer[V]]
@@ -66,35 +68,12 @@ object ProducerSettings {
       "Key serializer should be defined or declared in configuration"
     )
     require(
-      keySerializer.isDefined || properties.contains(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG),
+      valueSerializer.isDefined || properties.contains(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG),
       "Value serializer should be defined or declared in configuration"
     )
     val closeTimeout = config.getDuration("close-timeout", TimeUnit.MILLISECONDS).millis
     val parallelism = config.getInt("parallelism")
     new ProducerSettings[K, V](properties, keySerializer, valueSerializer, closeTimeout, parallelism)
-  }
-
-  /**
-   * Create settings from the default configuration
-   * `akka.kafka.producer`.
-   */
-  def apply[K, V](
-    system: ActorSystem,
-    keySerializer: Serializer[K],
-    valueSerializer: Serializer[V]
-  ): ProducerSettings[K, V] =
-    apply(system, Some(keySerializer), Some(valueSerializer))
-
-  /**
-   * Create settings from a configuration with the same layout as
-   * the default configuration `akka.kafka.producer`.
-   */
-  def apply[K, V](
-    config: Config,
-    keySerializer: Serializer[K],
-    valueSerializer: Serializer[V]
-  ): ProducerSettings[K, V] = {
-    apply(config, Some(keySerializer), Some(valueSerializer))
   }
 
   /**
@@ -122,24 +101,26 @@ object ProducerSettings {
   /**
    * Java API: Create settings from the default configuration
    * `akka.kafka.producer`.
+   * Key or value serializer can be passed explicitly or retrieved from configuration.
    */
   def create[K, V](
     system: ActorSystem,
-    keySerializer: Serializer[K],
-    valueSerializer: Serializer[V]
+    keySerializer: Optional[Serializer[K]],
+    valueSerializer: Optional[Serializer[V]]
   ): ProducerSettings[K, V] =
-    apply(system, Option(keySerializer), Option(valueSerializer))
+    apply(system, keySerializer.asScala, valueSerializer.asScala)
 
   /**
    * Java API: Create settings from a configuration with the same layout as
    * the default configuration `akka.kafka.producer`.
+   * Key or value serializer can be passed explicitly or retrieved from configuration.
    */
   def create[K, V](
     config: Config,
-    keySerializer: Serializer[K],
-    valueSerializer: Serializer[V]
+    keySerializer: Optional[Serializer[K]],
+    valueSerializer: Optional[Serializer[V]]
   ): ProducerSettings[K, V] =
-    apply(config, Option(keySerializer), Option(valueSerializer))
+    apply(config, keySerializer.asScala, valueSerializer.asScala)
 
 }
 

--- a/core/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
+++ b/core/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
@@ -19,7 +19,7 @@ class ConsumerSettingsSpec extends WordSpecLike with Matchers {
         akka.kafka.consumer.kafka-clients.foo = bar
         akka.kafka.consumer.kafka-clients.client.id = client1
         """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
-      val settings = ConsumerSettings(conf, new ByteArrayDeserializer, new StringDeserializer)
+      val settings = ConsumerSettings(conf, Some(new ByteArrayDeserializer), Some(new StringDeserializer))
       settings.getProperty("bootstrap.servers") should ===("localhost:9092")
       settings.getProperty("client.id") should ===("client1")
       settings.getProperty("foo") should ===("bar")
@@ -42,11 +42,11 @@ class ConsumerSettingsSpec extends WordSpecLike with Matchers {
         akka.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
         akka.kafka.consumer.kafka-clients.parallelism = 1
         """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
-      val settings = ConsumerSettings(conf, new ByteArrayDeserializer, new StringDeserializer)
+      val settings = ConsumerSettings(conf, Some(new ByteArrayDeserializer), Some(new StringDeserializer))
       settings.getProperty("bootstrap.servers") should ===("localhost:9092")
     }
 
-    "throw IllegalArgumentException if no value deserializer defined" in {
+    "throw IllegalArgumentException if no value deserializer defined in" in {
       val conf = ConfigFactory.parseString("""
         akka.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
         akka.kafka.consumer.kafka-clients.key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
@@ -58,7 +58,7 @@ class ConsumerSettingsSpec extends WordSpecLike with Matchers {
       exception.getMessage should ===("requirement failed: Value deserializer should be defined or declared in configuration")
     }
 
-    "throw IllegalArgumentException if no key deserializer defined" in {
+    "throw IllegalArgumentException if no key deserializer defined in" in {
       val conf = ConfigFactory.parseString("""
         akka.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
         akka.kafka.consumer.kafka-clients.value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
@@ -66,6 +66,28 @@ class ConsumerSettingsSpec extends WordSpecLike with Matchers {
         """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
       val exception = intercept[IllegalArgumentException]{
         ConsumerSettings(conf)
+      }
+      exception.getMessage should ===("requirement failed: Key deserializer should be defined or declared in configuration")
+    }
+
+    "throw IllegalArgumentException if no value deserializer defined as args config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.consumer.kafka-clients.client.id = client1
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
+      val exception = intercept[IllegalArgumentException]{
+        ConsumerSettings(conf, Some(new ByteArrayDeserializer), None)
+      }
+      exception.getMessage should ===("requirement failed: Value deserializer should be defined or declared in configuration")
+    }
+
+    "throw IllegalArgumentException if no key deserializer defined as args config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.consumer.kafka-clients.client.id = client1
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
+      val exception = intercept[IllegalArgumentException]{
+        ConsumerSettings(conf, None, Some(new StringDeserializer))
       }
       exception.getMessage should ===("requirement failed: Key deserializer should be defined or declared in configuration")
     }

--- a/core/src/test/scala/akka/kafka/ProducerSettingsSpec.scala
+++ b/core/src/test/scala/akka/kafka/ProducerSettingsSpec.scala
@@ -28,11 +28,11 @@ class ProducerSettingsSpec extends WordSpecLike with Matchers {
         akka.kafka.producer.kafka-clients.bootstrap.servers = "localhost:9092"
         akka.kafka.producer.kafka-clients.parallelism = 1
         """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.producer")
-      val settings = ProducerSettings(conf, new ByteArraySerializer, new StringSerializer)
+      val settings = ProducerSettings(conf, Some(new ByteArraySerializer), Some(new StringSerializer))
       settings.properties("bootstrap.servers") should ===("localhost:9092")
     }
 
-    "throw IllegalArgumentException if no value serializer defined" in {
+    "throw IllegalArgumentException if no value serializer defined in config" in {
       val conf = ConfigFactory.parseString("""
         akka.kafka.producer.kafka-clients.bootstrap.servers = "localhost:9092"
         akka.kafka.producer.kafka-clients.parallelism = 1
@@ -44,7 +44,7 @@ class ProducerSettingsSpec extends WordSpecLike with Matchers {
       exception.getMessage should ===("requirement failed: Value serializer should be defined or declared in configuration")
     }
 
-    "throw IllegalArgumentException if no key serializer defined" in {
+    "throw IllegalArgumentException if no key serializer defined in config" in {
       val conf = ConfigFactory.parseString("""
         akka.kafka.producer.kafka-clients.bootstrap.servers = "localhost:9092"
         akka.kafka.producer.kafka-clients.parallelism = 1
@@ -52,6 +52,28 @@ class ProducerSettingsSpec extends WordSpecLike with Matchers {
         """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.producer")
       val exception = intercept[IllegalArgumentException]{
         ProducerSettings(conf)
+      }
+      exception.getMessage should ===("requirement failed: Key serializer should be defined or declared in configuration")
+    }
+
+    "throw IllegalArgumentException if no value serializer defined as args config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.producer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.producer.kafka-clients.parallelism = 1
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.producer")
+      val exception = intercept[IllegalArgumentException]{
+        ProducerSettings(conf, Some(new ByteArraySerializer), None)
+      }
+      exception.getMessage should ===("requirement failed: Value serializer should be defined or declared in configuration")
+    }
+
+    "throw IllegalArgumentException if no key serializer defined as args config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.producer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.producer.kafka-clients.parallelism = 1
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.producer")
+      val exception = intercept[IllegalArgumentException]{
+        ProducerSettings(conf, None, Some(new StringSerializer))
       }
       exception.getMessage should ===("requirement failed: Key serializer should be defined or declared in configuration")
     }

--- a/core/src/test/scala/akka/kafka/internal/ProducerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ProducerTest.scala
@@ -62,7 +62,7 @@ class ProducerTest(_system: ActorSystem)
     Result(meta.offset, Message(record, NotUsed))
   }
 
-  val settings = ProducerSettings(system, new StringSerializer, new StringSerializer)
+  val settings = ProducerSettings(system, Some(new StringSerializer), Some(new StringSerializer))
 
   def testProducerFlow[P](mock: ProducerMock[K, V]): Flow[Message[K, V, P], Result[K, V, P], NotUsed] =
     Flow.fromGraph(new ProducerStage[K, V, P](settings, () => mock.mock))

--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -66,7 +66,7 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
     group2 = "group2-" + uuid
   }
 
-  val producerSettings = ProducerSettings(system, new ByteArraySerializer, new StringSerializer)
+  val producerSettings = ProducerSettings(system, Some(new ByteArraySerializer), Some(new StringSerializer))
     .withBootstrapServers(bootstrapServers)
 
   def givenInitializedTopic(): Unit = {
@@ -92,7 +92,7 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
   }
 
   def createConsumerSettings(group: String): ConsumerSettings[Array[Byte], String] = {
-    ConsumerSettings(system, new ByteArrayDeserializer, new StringDeserializer)
+    ConsumerSettings(system, Some(new ByteArrayDeserializer), Some(new StringDeserializer))
       .withBootstrapServers("localhost:9092")
       .withGroupId(group)
       .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")

--- a/docs/src/test/java/sample/javadsl/ConsumerExample.java
+++ b/docs/src/test/java/sample/javadsl/ConsumerExample.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import scala.concurrent.duration.Duration;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -45,14 +46,14 @@ abstract class ConsumerExample {
 
   // #settings
   protected final ConsumerSettings<byte[], String> consumerSettings =
-      ConsumerSettings.create(system, new ByteArrayDeserializer(), new StringDeserializer())
+      ConsumerSettings.create(system, Optional.of(new ByteArrayDeserializer()), Optional.of(new StringDeserializer()))
     .withBootstrapServers("localhost:9092")
     .withGroupId("group1")
     .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
   // #settings
 
   protected final ProducerSettings<byte[], String> producerSettings =
-      ProducerSettings.create(system, new ByteArraySerializer(), new StringSerializer())
+      ProducerSettings.create(system, Optional.of(new ByteArraySerializer()), Optional.of(new StringSerializer()))
     .withBootstrapServers("localhost:9092");
 
   // #db

--- a/docs/src/test/java/sample/javadsl/ProducerExample.java
+++ b/docs/src/test/java/sample/javadsl/ProducerExample.java
@@ -14,6 +14,7 @@ import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
@@ -26,7 +27,7 @@ abstract class ProducerExample {
 
   // #settings
   protected final ProducerSettings<byte[], String> producerSettings = ProducerSettings
-    .create(system, new ByteArraySerializer(), new StringSerializer())
+    .create(system, Optional.of(new ByteArraySerializer()), Optional.of(new StringSerializer()))
     .withBootstrapServers("localhost:9092");
   // #settings
 

--- a/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
+++ b/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
@@ -27,13 +27,13 @@ trait ConsumerExample {
   val maxPartitions = 100
 
   // #settings
-  val consumerSettings = ConsumerSettings(system, new ByteArrayDeserializer, new StringDeserializer)
+  val consumerSettings = ConsumerSettings(system, Some(new ByteArrayDeserializer), Some(new StringDeserializer))
     .withBootstrapServers("localhost:9092")
     .withGroupId("group1")
     .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
   //#settings
 
-  val producerSettings = ProducerSettings(system, new ByteArraySerializer, new StringSerializer)
+  val producerSettings = ProducerSettings(system, Some(new ByteArraySerializer), Some(new StringSerializer))
     .withBootstrapServers("localhost:9092")
 
   def business[T] = Flow[T]

--- a/docs/src/test/scala/sample/scaladsl/ProducerExample.scala
+++ b/docs/src/test/scala/sample/scaladsl/ProducerExample.scala
@@ -22,7 +22,7 @@ trait ProducerExample {
   val system = ActorSystem("example")
 
   // #settings
-  val producerSettings = ProducerSettings(system, new ByteArraySerializer, new StringSerializer)
+  val producerSettings = ProducerSettings(system, Some(new ByteArraySerializer), Some(new StringSerializer))
     .withBootstrapServers("localhost:9092")
   // #settings
 


### PR DESCRIPTION
* Now APIs (Consumer and Producer) only have `apply` with `Option` parameters and `create` with `Optional` parameters
* Additional two new tests were added for both Consumer/Producer Settings. One of these tests for the Producer reproduce the validation error explained in #211
* Change the `ProducerSettings` API to resolve the bug
* Change broken code due to API modifications