### PR TITLE
Allow Option/Optional key/value serde in Consumer/Producer Settings #211 #212

### DIFF
--- a/core/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
+++ b/core/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
@@ -33,7 +33,7 @@ class ConsumerSettingsSpec extends WordSpecLike with Matchers {
         akka.kafka.consumer.kafka-clients.value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
         akka.kafka.consumer.kafka-clients.client.id = client1
         """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
-      val settings = ConsumerSettings(conf)
+      val settings = ConsumerSettings(conf, None, None)
       settings.getProperty("bootstrap.servers") should ===("localhost:9092")
     }
 
@@ -46,6 +46,26 @@ class ConsumerSettingsSpec extends WordSpecLike with Matchers {
       settings.getProperty("bootstrap.servers") should ===("localhost:9092")
     }
 
+    "handle key deserializer passed as args config and value deserializer defined in config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.consumer.kafka-clients.value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+        akka.kafka.consumer.kafka-clients.client.id = client1
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
+      val settings = ConsumerSettings(conf, Some(new ByteArrayDeserializer), None)
+      settings.getProperty("bootstrap.servers") should ===("localhost:9092")
+    }
+
+    "handle value deserializer passed as args config and key deserializer defined in config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.consumer.kafka-clients.key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+        akka.kafka.consumer.kafka-clients.client.id = client1
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
+      val settings = ConsumerSettings(conf, None, Some(new ByteArrayDeserializer))
+      settings.getProperty("bootstrap.servers") should ===("localhost:9092")
+    }
+
     "throw IllegalArgumentException if no value deserializer defined" in {
       val conf = ConfigFactory.parseString("""
         akka.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
@@ -53,7 +73,30 @@ class ConsumerSettingsSpec extends WordSpecLike with Matchers {
         akka.kafka.consumer.kafka-clients.client.id = client1
         """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
       val exception = intercept[IllegalArgumentException]{
-        ConsumerSettings(conf)
+        ConsumerSettings(conf, None, None)
+      }
+      exception.getMessage should ===("requirement failed: Value deserializer should be defined or declared in configuration")
+    }
+
+    "throw IllegalArgumentException if no value deserializer defined (null case). Key serializer passed as args config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.consumer.kafka-clients.client.id = client1
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
+      val exception = intercept[IllegalArgumentException]{
+        ConsumerSettings(conf, new ByteArrayDeserializer, null)
+      }
+      exception.getMessage should ===("requirement failed: Value deserializer should be defined or declared in configuration")
+    }
+
+    "throw IllegalArgumentException if no value deserializer defined (null case). Key serializer defined in config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.consumer.kafka-clients.key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+        akka.kafka.consumer.kafka-clients.client.id = client1
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
+      val exception = intercept[IllegalArgumentException]{
+        ConsumerSettings(conf, None, null)
       }
       exception.getMessage should ===("requirement failed: Value deserializer should be defined or declared in configuration")
     }
@@ -65,7 +108,30 @@ class ConsumerSettingsSpec extends WordSpecLike with Matchers {
         akka.kafka.consumer.kafka-clients.client.id = client1
         """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
       val exception = intercept[IllegalArgumentException]{
-        ConsumerSettings(conf)
+        ConsumerSettings(conf, None, None)
+      }
+      exception.getMessage should ===("requirement failed: Key deserializer should be defined or declared in configuration")
+    }
+
+    "throw IllegalArgumentException if no key deserializer defined (null case). Value serializer passed as args config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.consumer.kafka-clients.client.id = client1
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
+      val exception = intercept[IllegalArgumentException]{
+        ConsumerSettings(conf, null, new ByteArrayDeserializer)
+      }
+      exception.getMessage should ===("requirement failed: Key deserializer should be defined or declared in configuration")
+    }
+
+    "throw IllegalArgumentException if no key deserializer defined (null case). Value serializer defined in config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.consumer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.consumer.kafka-clients.value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+        akka.kafka.consumer.kafka-clients.client.id = client1
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.consumer")
+      val exception = intercept[IllegalArgumentException]{
+        ConsumerSettings(conf, null, None)
       }
       exception.getMessage should ===("requirement failed: Key deserializer should be defined or declared in configuration")
     }

--- a/core/src/test/scala/akka/kafka/ProducerSettingsSpec.scala
+++ b/core/src/test/scala/akka/kafka/ProducerSettingsSpec.scala
@@ -19,7 +19,7 @@ class ProducerSettingsSpec extends WordSpecLike with Matchers {
         akka.kafka.producer.kafka-clients.key.serializer = org.apache.kafka.common.serialization.StringSerializer
         akka.kafka.producer.kafka-clients.value.serializer = org.apache.kafka.common.serialization.StringSerializer
         """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.producer")
-      val settings = ProducerSettings(conf)
+      val settings = ProducerSettings(conf, None, None)
       settings.properties("bootstrap.servers") should ===("localhost:9092")
     }
 
@@ -32,6 +32,26 @@ class ProducerSettingsSpec extends WordSpecLike with Matchers {
       settings.properties("bootstrap.servers") should ===("localhost:9092")
     }
 
+    "handle key serializer passed as args config and value serializer defined in config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.producer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.producer.kafka-clients.parallelism = 1
+        akka.kafka.producer.kafka-clients.value.serializer = org.apache.kafka.common.serialization.StringSerializer
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.producer")
+      val settings = ProducerSettings(conf, Some(new ByteArraySerializer), None)
+      settings.properties("bootstrap.servers") should ===("localhost:9092")
+    }
+
+    "handle value serializer passed as args config and key serializer defined in config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.producer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.producer.kafka-clients.parallelism = 1
+        akka.kafka.producer.kafka-clients.key.serializer = org.apache.kafka.common.serialization.StringSerializer
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.producer")
+      val settings = ProducerSettings(conf, None, Some(new ByteArraySerializer))
+      settings.properties("bootstrap.servers") should ===("localhost:9092")
+    }
+
     "throw IllegalArgumentException if no value serializer defined" in {
       val conf = ConfigFactory.parseString("""
         akka.kafka.producer.kafka-clients.bootstrap.servers = "localhost:9092"
@@ -39,7 +59,30 @@ class ProducerSettingsSpec extends WordSpecLike with Matchers {
         akka.kafka.producer.kafka-clients.key.serializer = org.apache.kafka.common.serialization.StringSerializer
         """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.producer")
       val exception = intercept[IllegalArgumentException]{
-        ProducerSettings(conf)
+        ProducerSettings(conf, None, None)
+      }
+      exception.getMessage should ===("requirement failed: Value serializer should be defined or declared in configuration")
+    }
+
+    "throw IllegalArgumentException if no value serializer defined (null case). Key serializer passed as args config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.producer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.producer.kafka-clients.parallelism = 1
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.producer")
+      val exception = intercept[IllegalArgumentException]{
+        ProducerSettings(conf, new ByteArraySerializer, null)
+      }
+      exception.getMessage should ===("requirement failed: Value serializer should be defined or declared in configuration")
+    }
+
+    "throw IllegalArgumentException if no value serializer defined (null case). Key serializer defined in config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.producer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.producer.kafka-clients.parallelism = 1
+        akka.kafka.producer.kafka-clients.key.serializer = org.apache.kafka.common.serialization.StringSerializer
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.producer")
+      val exception = intercept[IllegalArgumentException]{
+        ProducerSettings(conf, None, null)
       }
       exception.getMessage should ===("requirement failed: Value serializer should be defined or declared in configuration")
     }
@@ -51,7 +94,30 @@ class ProducerSettingsSpec extends WordSpecLike with Matchers {
         akka.kafka.producer.kafka-clients.value.serializer = org.apache.kafka.common.serialization.StringSerializer
         """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.producer")
       val exception = intercept[IllegalArgumentException]{
-        ProducerSettings(conf)
+        ProducerSettings(conf, None, None)
+      }
+      exception.getMessage should ===("requirement failed: Key serializer should be defined or declared in configuration")
+    }
+
+    "throw IllegalArgumentException if no key serializer defined (null case). Value serializer passed as args config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.producer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.producer.kafka-clients.parallelism = 1
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.producer")
+      val exception = intercept[IllegalArgumentException]{
+        ProducerSettings(conf, null, new ByteArraySerializer)
+      }
+      exception.getMessage should ===("requirement failed: Key serializer should be defined or declared in configuration")
+    }
+
+    "throw IllegalArgumentException if no key serializer defined (null case). Value serializer defined in config" in {
+      val conf = ConfigFactory.parseString("""
+        akka.kafka.producer.kafka-clients.bootstrap.servers = "localhost:9092"
+        akka.kafka.producer.kafka-clients.parallelism = 1
+        akka.kafka.producer.kafka-clients.value.serializer = org.apache.kafka.common.serialization.StringSerializer
+        """).withFallback(ConfigFactory.load()).getConfig("akka.kafka.producer")
+      val exception = intercept[IllegalArgumentException]{
+        ProducerSettings(conf, null, None)
       }
       exception.getMessage should ===("requirement failed: Key serializer should be defined or declared in configuration")
     }


### PR DESCRIPTION
This PR is the result of the discussion in #213. The old one does not apply at all.

* Now APIs (Consumer and Producer) allows `apply` with `Option` parameters and `create` with `Optional` parameters. If they are not passed to settings will check configuration and only then throw illegal argument exception.

```scala
def apply[K, V](
      system: ActorSystem,
      keyDeserializer: Option[Deserializer[K]],
      valueDeserializer: Option[Deserializer[V]])

def apply[K, V](
      config: Config,
      keyDeserializer: Option[Deserializer[K]],
      valueDeserializer: Option[Deserializer[V]])

 def apply[K, V](
      system: ActorSystem,
      keyDeserializer: Deserializer[K],
      valueDeserializer: Deserializer[V])

def apply[K, V](
      config: Config,
      keyDeserializer: Deserializer[K],
      valueDeserializer: Deserializer[V])
```
**Similar 4 for java**

* Remove the other variant that has no serializer params.

* Additional two new tests were added for both Consumer/Producer Settings. One of these tests for the Producer reproduce the validation error explained in #211.

* Change the `ProducerSettings` API to resolve the bug.