### PR TITLE
Consumer error handling

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -52,10 +52,10 @@ akka.kafka.consumer {
   # aborted after this timeout. The KafkaConsumerActor will throw
   # org.apache.kafka.common.errors.WakeupException which will be ignored
   # until max-wakeups limit gets exceeded.
-  wakeup-timeout = 10s
+  wakeup-timeout = 3s
 
   # After exceeding maxinum wakeups the consumer will stop and the stage will fail.
-  max-wakeups = 3
+  max-wakeups = 10
   
   # Fully qualified config path which holds the dispatcher configuration
   # to be used by the KafkaConsumerActor. Some blocking may occur.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -50,10 +50,12 @@ akka.kafka.consumer {
   
   # If the KafkaConsumer can't connect to the broker the poll will be
   # aborted after this timeout. The KafkaConsumerActor will throw
-  # org.apache.kafka.common.errors.WakeupException, which can be handled
-  # with Actor supervision strategy.
-  # This is subject for change, see issue #224
+  # org.apache.kafka.common.errors.WakeupException which will be ignored
+  # until max-wakeups limit gets exceeded.
   wakeup-timeout = 10s
+
+  # After exceeding maxinum wakeups the consumer will stop and the stage will fail.
+  max-wakeups = 3
   
   # Fully qualified config path which holds the dispatcher configuration
   # to be used by the KafkaConsumerActor. Some blocking may occur.

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -135,9 +135,10 @@ object ConsumerSettings {
     val closeTimeout = config.getDuration("close-timeout", TimeUnit.MILLISECONDS).millis
     val commitTimeout = config.getDuration("commit-timeout", TimeUnit.MILLISECONDS).millis
     val wakeupTimeout = config.getDuration("wakeup-timeout", TimeUnit.MILLISECONDS).millis
+    val maxWakeups = config.getInt("max-wakeups")
     val dispatcher = config.getString("use-dispatcher")
     new ConsumerSettings[K, V](properties, keyDeserializer, valueDeserializer,
-      pollInterval, pollTimeout, stopTimeout, closeTimeout, commitTimeout, wakeupTimeout, dispatcher)
+      pollInterval, pollTimeout, stopTimeout, closeTimeout, commitTimeout, wakeupTimeout, maxWakeups, dispatcher)
   }
 
   /**
@@ -231,6 +232,7 @@ class ConsumerSettings[K, V](
     val closeTimeout: FiniteDuration,
     val commitTimeout: FiniteDuration,
     val wakeupTimeout: FiniteDuration,
+    val maxWakeups: Int,
     val dispatcher: String
 ) {
 
@@ -286,11 +288,12 @@ class ConsumerSettings[K, V](
     closeTimeout: FiniteDuration = closeTimeout,
     commitTimeout: FiniteDuration = commitTimeout,
     wakeupTimeout: FiniteDuration = wakeupTimeout,
+    maxWakeups: Int = maxWakeups,
     dispatcher: String = dispatcher
   ): ConsumerSettings[K, V] =
     new ConsumerSettings[K, V](properties, keyDeserializer, valueDeserializer,
       pollInterval, pollTimeout, stopTimeout, closeTimeout, commitTimeout, wakeupTimeout,
-      dispatcher)
+      maxWakeups, dispatcher)
 
   /**
    * Create a `KafkaConsumer` instance from the settings.

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -278,6 +278,9 @@ class ConsumerSettings[K, V](
   def withDispatcher(dispatcher: String): ConsumerSettings[K, V] =
     copy(dispatcher = dispatcher)
 
+  def withMaxWakeups(maxWakeups: Int): ConsumerSettings[K, V] =
+    copy(maxWakeups = maxWakeups)
+
   private def copy(
     properties: Map[String, String] = properties,
     keyDeserializer: Option[Deserializer[K]] = keyDeserializerOpt,

--- a/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
@@ -207,8 +207,6 @@ private[kafka] class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V])
           context.stop(self)
           null
       }
-      finally
-        wakeupTask.cancel()
 
     if (requests.isEmpty) {
       try {
@@ -236,8 +234,11 @@ private[kafka] class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V])
       finally wakeupTask.cancel()
 
     }
-    else
-      processResult(partitionsToFetch, tryPoll(pollTimeout().toMillis))
+    else {
+      val result = tryPoll(pollTimeout().toMillis)
+      wakeupTask.cancel()
+      processResult(partitionsToFetch, result)
+    }
 
     if (stopInProgress && commitsInProgress == 0) {
       context.stop(self)

--- a/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
@@ -80,7 +80,6 @@ private[kafka] class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V])
   var requests = Map.empty[ActorRef, RequestMessages]
   var consumer: KafkaConsumer[K, V] = _
   var commitsInProgress = 0
-  val MaxWakeups = 3
   var wakeups = 0
   var stopInProgress = false
 
@@ -194,7 +193,7 @@ private[kafka] class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V])
       catch {
         case w: WakeupException =>
           wakeups = wakeups + 1
-          if (wakeups == MaxWakeups) {
+          if (wakeups == settings.maxWakeups) {
             log.error("WakeupException limit exceeded, stopping.")
             context.stop(self)
           }

--- a/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
@@ -202,11 +202,12 @@ private[kafka] class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V])
           case w: WakeupException =>
             wakeups = wakeups + 1
             if (wakeups == MaxWakeups) {
-              log.error("WakeupException limit exceeded, stopping")
+              log.error("WakeupException limit exceeded, stopping.")
               context.stop(self)
             }
             else
-              log.warning("Consumer interrupted with WakeupException after timeout")
+              log.warning(s"Consumer interrupted with WakeupException after timeout. Message: ${w.getMessage}. " +
+                s"Current value of akka.kafka.consumer.wakeup-timeout is ${settings.wakeupTimeout}")
           case NonFatal(e) =>
             log.error(e, "Exception when polling from consumer")
             context.stop(self)

--- a/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
@@ -235,8 +235,7 @@ private[kafka] class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V])
 
     }
     else {
-      val result = tryPoll(pollTimeout().toMillis)
-      wakeupTask.cancel()
+      val result = try tryPoll(pollTimeout().toMillis) finally wakeupTask.cancel()
       processResult(partitionsToFetch, result)
     }
 

--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -6,5 +6,8 @@ akka {
   test {
     single-expect-default = 10s
   }
+  kafka.consumer {
+    max-wakeups = 3
+  }
 }
 

--- a/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
@@ -4,6 +4,7 @@
  */
 package akka.kafka.internal
 
+import java.util
 import java.util.{List => JList, Map => JMap, Set => JSet}
 
 import akka.Done
@@ -20,6 +21,7 @@ import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.TestKit
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.WakeupException
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.mockito
 import org.mockito.Mockito
@@ -89,6 +91,54 @@ class ConsumerTest(_system: ActorSystem)
       }
     }
     Consumer.committableSource(settings, TopicSubscription(topics))
+  }
+
+  it should "fail stream when poll() fails with unhandled exception" in {
+    val mock = new FailingConsumerMock[K, V](new Exception("Fatal Kafka error"), failOnCallNumber = 1)
+
+    val probe = testSource(mock)
+      .toMat(TestSink.probe)(Keep.right)
+      .run()
+
+    probe
+      .request(1)
+      .expectError()
+  }
+
+  it should "not fail stream when poll() fails twice with WakeupException" in {
+    val mock = new FailingConsumerMock[K, V](new WakeupException(), failOnCallNumber = 1, 2)
+
+    val probe = testSource(mock)
+      .toMat(TestSink.probe)(Keep.right)
+      .run()
+
+    probe
+      .request(1)
+      .expectNoMsg()
+  }
+
+  it should "not fail stream when poll() fails twice, then succeeds, then fails twice with WakeupException" in {
+    val mock = new FailingConsumerMock[K, V](new WakeupException(), failOnCallNumber = 1, 2, 4, 5)
+
+    val probe = testSource(mock)
+      .toMat(TestSink.probe)(Keep.right)
+      .run()
+
+    probe
+      .request(1)
+      .expectNoMsg()
+  }
+
+  it should "not fail stream when poll() fail limit exceeded" in {
+    val mock = new FailingConsumerMock[K, V](new WakeupException(), failOnCallNumber = 1, 2, 3)
+
+    val probe = testSource(mock)
+      .toMat(TestSink.probe)(Keep.right)
+      .run()
+
+    probe
+      .request(1)
+      .expectError()
   }
 
   it should "complete stage when stream control.stop called" in {
@@ -567,4 +617,17 @@ class ConsumerMock[K, V](handler: ConsumerMock.CommitHandler = ConsumerMock.notI
   def verifyPoll(mode: VerificationMode = Mockito.atLeastOnce()) = {
     verify(mock, mode).poll(mockito.Matchers.any[Long])
   }
+}
+
+class FailingConsumerMock[K, V](throwable: Throwable, failOnCallNumber: Int*) extends ConsumerMock[K, V] {
+  var callNumber = 0
+
+  Mockito.when(mock.poll(mockito.Matchers.any[Long])).thenAnswer(new Answer[ConsumerRecords[K, V]] {
+    override def answer(invocation: InvocationOnMock) = FailingConsumerMock.this.synchronized {
+      callNumber = callNumber + 1
+      if (failOnCallNumber.contains(callNumber))
+        throw throwable
+      else new ConsumerRecords[K, V](Map.empty[TopicPartition, java.util.List[ConsumerRecord[K, V]]].asJava)
+    }
+  })
 }

--- a/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
@@ -85,7 +85,7 @@ class ConsumerTest(_system: ActorSystem)
 
   def testSource(mock: ConsumerMock[K, V], groupId: String = "group1", topics: Set[String] = Set("topic")): Source[CommittableMessage[K, V], Control] = {
     val settings = new ConsumerSettings(Map(ConsumerConfig.GROUP_ID_CONFIG -> groupId), Some(new StringDeserializer), Some(new StringDeserializer),
-      1.milli, 1.milli, 1.second, 1.second, 1.second, 5.seconds, "akka.kafka.default-dispatcher") {
+      1.milli, 1.milli, 1.second, 1.second, 1.second, 5.seconds, 3, "akka.kafka.default-dispatcher") {
       override def createKafkaConsumer(): KafkaConsumer[K, V] = {
         mock.mock
       }


### PR DESCRIPTION
- WakeupException is swallowed until limit is exceeded, then actor stops
- Any other exception stops the actor immediately
- Refs #227 #224