### PR TITLE
added RecordMetada value to ProducerMessage.Result case class while i…

### DIFF
--- a/core/src/main/scala/akka/kafka/ProducerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ProducerMessage.scala
@@ -36,7 +36,6 @@ object ProducerMessage {
    */
   final case class Result[K, V, PassThrough](
       metadata: RecordMetadata,
-      //    offset: Long,
       message: Message[K, V, PassThrough]
   ) {
     def offset = metadata.offset()

--- a/core/src/main/scala/akka/kafka/ProducerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ProducerMessage.scala
@@ -31,12 +31,12 @@ object ProducerMessage {
 
   /**
    * Output element of `Consumer#flow`. Emitted when the message has been
-   * successfully published. Includes the original message and the
+   * successfully published. Includes the original message, metadata returned from KafkaProducer and the
    * `offset` of the produced message.
    */
   final case class Result[K, V, PassThrough](
-      metadata: RecordMetadata,
-      message: Message[K, V, PassThrough]
+    metadata: RecordMetadata,
+    message: Message[K, V, PassThrough]
   ) {
     def offset = metadata.offset()
   }

--- a/core/src/main/scala/akka/kafka/ProducerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ProducerMessage.scala
@@ -4,7 +4,7 @@
  */
 package akka.kafka
 
-import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
 
 /**
  * Classes that are used in both [[javadsl.Producer]] and
@@ -35,8 +35,11 @@ object ProducerMessage {
    * `offset` of the produced message.
    */
   final case class Result[K, V, PassThrough](
-    offset: Long,
-    message: Message[K, V, PassThrough]
-  )
+      metadata: RecordMetadata,
+      //    offset: Long,
+      message: Message[K, V, PassThrough]
+  ) {
+    def offset = metadata.offset()
+  }
 
 }

--- a/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
@@ -64,7 +64,7 @@ private[kafka] class ProducerStage[K, V, P](
           producer.send(msg.record, new Callback {
             override def onCompletion(metadata: RecordMetadata, exception: Exception) = {
               if (exception == null)
-                r.success(Result(metadata.offset, msg))
+                r.success(Result(metadata, msg))
               else
                 r.failure(exception)
 

--- a/core/src/test/scala/akka/kafka/internal/ProducerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ProducerTest.scala
@@ -59,7 +59,7 @@ class ProducerTest(_system: ActorSystem)
   def toMessage(tuple: (Record, RecordMetadata)) = Message(tuple._1, NotUsed)
   def toResult(tuple: (Record, RecordMetadata)) = {
     val (record: Record, meta: RecordMetadata) = tuple
-    Result(meta.offset, Message(record, NotUsed))
+    Result(meta, Message(record, NotUsed))
   }
 
   val settings = ProducerSettings(system, new StringSerializer, new StringSerializer)


### PR DESCRIPTION
…ncluding an offset function for backward compatibility. ProducerStage is now filling in the RecordMetadata it got from the kafka producer onCompletion callback into the ProcuderMessage it returns