### PR TITLE
Remove ignore for test "resume consumer from committed offset"

### DIFF
--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -125,7 +125,7 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
     }
 
     // FIXME flaky test: https://github.com/akka/reactive-kafka/issues/203
-    "resume consumer from committed offset" ignore {
+    "resume consumer from committed offset" in {
       val topic1 = createTopic(1)
       val group1 = createGroup(1)
       val group2 = createGroup(2)


### PR DESCRIPTION
This PR is for triggering the Travis build in investigating

  flaky test: https://github.com/akka/reactive-kafka/issues/203