### PR TITLE
Remove ignore in test "resume consumer from committed offset"

### DIFF
--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -124,8 +124,7 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
       probe.cancel()
     }
 
-    // FIXME flaky test: https://github.com/akka/reactive-kafka/issues/203
-    "resume consumer from committed offset" ignore {
+    "resume consumer from committed offset" in {
       val topic1 = createTopic(1)
       val group1 = createGroup(1)
       val group2 = createGroup(2)


### PR DESCRIPTION
https://github.com/akka/reactive-kafka/issues/203

After triggering 12 builds on Travis there were no failures.  The issue was likely
resolved by the wakeUp config changes (increased the timeout and maxWakeUps)