### PR TITLE
Adding cross build for Scala 2.12 and upgrading to Kafka 0.10.1.1. Fixes #256.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: scala
 sudo: false
 scala:
   - "2.11.8"
-  - "2.12.1"
 jdk:
   - oraclejdk8
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: scala
 sudo: false
 scala:
   - "2.11.8"
+  - "2.12.1"
 jdk:
   - oraclejdk8
 env:
   matrix:
-    - SCRIPT="sbt -jvm-opts .travis-jvmopts test"
+    - SCRIPT="sbt -jvm-opts .travis-jvmopts +test"
 # important to use eval, otherwise "&&" is passed as an argument to sbt rather than being processed by bash
 script: eval $SCRIPT
 cache:

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/KafkaConsumerFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/KafkaConsumerFixtureGen.scala
@@ -8,7 +8,7 @@ import akka.kafka.benchmarks.app.RunTestCommand
 import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 case class KafkaConsumerTestFixture(topic: String, msgCount: Int, consumer: KafkaConsumer[Array[Byte], String]) {
   def close(): Unit = consumer.close()
@@ -33,7 +33,7 @@ object KafkaConsumerFixtures extends PerfFixtureHelpers {
     consumerJavaProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
 
     val consumer = new KafkaConsumer[Array[Byte], String](consumerJavaProps, new ByteArrayDeserializer, new StringDeserializer)
-    consumer.subscribe(Set(topic))
+    consumer.subscribe(Set(topic).asJava)
     KafkaConsumerTestFixture(topic, msgCount, consumer)
   }
   )

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/Timed.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/Timed.scala
@@ -4,7 +4,7 @@
  */
 package akka.kafka.benchmarks
 
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{ForkJoinPool, TimeUnit}
 
 import akka.kafka.benchmarks.app.RunTestCommand
 import com.codahale.metrics.{Meter, MetricRegistry, ScheduledReporter, Slf4jReporter}
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 
 object Timed extends LazyLogging {
 
-  implicit val ec = ExecutionContext.fromExecutor(new scala.concurrent.forkjoin.ForkJoinPool)
+  implicit val ec = ExecutionContext.fromExecutor(new ForkJoinPool)
 
   def reporter(metricRegistry: MetricRegistry): ScheduledReporter = {
     Slf4jReporter

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import de.heikoseeberger.sbtheader.HeaderPattern
 name := "akka-stream-kafka"
 
 val akkaVersion = "2.4.14"
-val kafkaVersion = "0.10.0.1"
+val kafkaVersion = "0.10.1.1"
 
 val kafkaClients = "org.apache.kafka" % "kafka-clients" % kafkaVersion
 
@@ -15,7 +15,7 @@ val commonDependencies = Seq(
 val coreDependencies = Seq(
   "com.typesafe.akka" %% "akka-stream" % akkaVersion,
   kafkaClients,
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "org.reactivestreams" % "reactive-streams-tck" % "1.0.0" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test",
   "junit" % "junit" % "4.12" % "test",
@@ -24,7 +24,7 @@ val coreDependencies = Seq(
   "ch.qos.logback" % "logback-classic" % "1.1.3" % "test",
   "org.slf4j" % "log4j-over-slf4j" % "1.7.12" % "test",
   "org.mockito" % "mockito-core" % "1.10.19" % "test",
-  "net.manub" %% "scalatest-embedded-kafka" % "0.7.1" % "test"
+  "net.manub" %% "scalatest-embedded-kafka" % "0.11.0" % "test"
     exclude("log4j", "log4j")
 )
 
@@ -36,6 +36,7 @@ val commonSettings =
   test in assembly := {},
   licenses := Seq("Apache License 2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
   scalaVersion := "2.11.8",
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.1"),
   crossVersion := CrossVersion.binary,
   scalacOptions ++= Seq(
   "-deprecation",
@@ -65,6 +66,9 @@ headers := headers.value ++ Map(
        |""".stripMargin
   )
 ))
+
+resolvers in ThisBuild ++= Seq(Resolver.bintrayRepo("manub", "maven"),
+  "Apache Staging" at "https://repository.apache.org/content/groups/staging")
 
 lazy val root =
   project.in( file(".") )
@@ -111,7 +115,7 @@ lazy val benchmarks = project
     name := "akka-stream-kafka-benchmarks",
     parallelExecution in Benchmark := false,
     libraryDependencies ++= commonDependencies ++ coreDependencies ++ Seq(
-      "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0",
+      "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
       "io.dropwizard.metrics" % "metrics-core" % "3.1.0",
       "ch.qos.logback" % "logback-classic" % "1.1.3",
       "org.slf4j" % "log4j-over-slf4j" % "1.7.12",

--- a/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
@@ -4,7 +4,6 @@
  */
 package akka.kafka.internal
 
-import java.util
 import java.util.{List => JList, Map => JMap, Set => JSet}
 
 import akka.Done
@@ -571,10 +570,9 @@ class ConsumerMock[K, V](handler: ConsumerMock.CommitHandler = ConsumerMock.notI
     })
     Mockito.when(result.commitAsync(mockito.Matchers.any[JMap[TopicPartition, OffsetAndMetadata]], mockito.Matchers.any[OffsetCommitCallback])).thenAnswer(new Answer[Unit] {
       override def answer(invocation: InvocationOnMock) = {
-        import scala.collection.JavaConversions._
         val offsets = invocation.getArgumentAt(0, classOf[JMap[TopicPartition, OffsetAndMetadata]])
         val callback = invocation.getArgumentAt(1, classOf[OffsetCommitCallback])
-        handler(mapAsScalaMap(offsets).toMap, callback)
+        handler(offsets.asScala.toMap, callback)
         ()
       }
     })

--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -29,13 +29,13 @@ import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer, StringDeserializer, StringSerializer}
-import org.scalactic.ConversionCheckedTripleEquals
+import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
 import org.scalatest.Assertions
 
 class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
     with WordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach
-    with ConversionCheckedTripleEquals {
+    with TypeCheckedTripleEquals {
 
   implicit val mat = ActorMaterializer()(system)
   implicit val ec = system.dispatcher

--- a/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
+++ b/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
@@ -9,7 +9,7 @@ import akka.kafka.ConsumerMessage.{CommittableMessage, CommittableOffsetBatch}
 import akka.kafka._
 import akka.kafka.scaladsl.{Consumer, Producer}
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
+import akka.stream.ActorMaterializer
 import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord}
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -17,6 +17,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer, StringDeserializer, StringSerializer}
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.util.{Failure, Success}
 import java.util.concurrent.atomic.AtomicLong
 
 trait ConsumerExample {
@@ -69,12 +70,12 @@ trait ConsumerExample {
   // #rocket
 
   def terminateWhenDone(result: Future[Done]): Unit = {
-    result.onFailure {
-      case e: Throwable =>
+    result.onComplete {
+      case Failure(e) =>
         system.log.error(e, e.getMessage)
         system.terminate()
+      case Success(_) => system.terminate()
     }
-    result.onSuccess { case _ => system.terminate() }
   }
 }
 

--- a/docs/src/test/scala/sample/scaladsl/ProducerExample.scala
+++ b/docs/src/test/scala/sample/scaladsl/ProducerExample.scala
@@ -7,7 +7,6 @@ package sample.scaladsl
 import akka.actor.ActorSystem
 import akka.kafka.ProducerMessage
 import akka.kafka.ProducerSettings
-import akka.kafka.scaladsl._
 import akka.kafka.scaladsl.Producer
 import akka.stream.scaladsl.Source
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -17,6 +16,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
 import scala.concurrent.Future
 import akka.Done
+import scala.util.{Failure, Success}
 
 trait ProducerExample {
   val system = ActorSystem("example")
@@ -33,12 +33,12 @@ trait ProducerExample {
   implicit val materializer = ActorMaterializer.create(system)
 
   def terminateWhenDone(result: Future[Done]): Unit = {
-    result.onFailure {
-      case e: Throwable =>
+    result.onComplete {
+      case Failure(e) =>
         system.log.error(e, e.getMessage)
         system.terminate()
+      case Success(_) => system.terminate()
     }
-    result.onSuccess { case _ => system.terminate() }
   }
 }
 


### PR DESCRIPTION
* Added resolvers for downstream dependencies.
* Updated travis configuration to cross build.
* Fixed a number of compiler errors caused by introducing Scala 2.12.
* Removed some unused imports.