### PR TITLE
Removing Apache Staging from resolvers.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,8 +67,7 @@ headers := headers.value ++ Map(
   )
 ))
 
-resolvers in ThisBuild ++= Seq(Resolver.bintrayRepo("manub", "maven"),
-  "Apache Staging" at "https://repository.apache.org/content/groups/staging")
+resolvers in ThisBuild ++= Seq(Resolver.bintrayRepo("manub", "maven"))
 
 lazy val root =
   project.in( file(".") )


### PR DESCRIPTION
I've added this as a workaround until `kafka_2.12` was published on Maven Central. Since it happened, it doesn't need to be in `build.sbt` anymore.