### PR TITLE
Issue 284: Fix commit batching from more than one stage

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/ConsumerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ConsumerStage.scala
@@ -91,19 +91,34 @@ private[kafka] object ConsumerStage {
 
   // This should be case class to be comparable based on ref and timeout. This comparison is used in CommittableOffsetBatchImpl
   case class KafkaAsyncConsumerCommitterRef(ref: ActorRef, timeout: FiniteDuration)(implicit ec: ExecutionContext) extends Committer {
+    import scala.collection.breakOut
     import akka.pattern.ask
     implicit val to = Timeout(timeout)
-    override def commit(offset: PartitionOffset): Future[Done] = {
-      val offsets = Map(
+    override def commit(offsets: Seq[PartitionOffset]): Future[Done] = {
+      val offsetsMap: Map[TopicPartition, Long] = offsets.map { offset =>
         new TopicPartition(offset.key.topic, offset.key.partition) -> (offset.offset + 1)
-      )
-      (ref ? Commit(offsets)).mapTo[Committed].map(_ => Done)
+      }(breakOut)
+      (ref ? Commit(offsetsMap)).mapTo[Committed].map(_ => Done)
     }
-    override def commit(batch: CommittableOffsetBatch): Future[Done] = {
-      val offsets = batch.offsets.map {
-        case (ctp, offset) => new TopicPartition(ctp.topic, ctp.partition) -> (offset + 1)
-      }
-      (ref ? Commit(offsets)).mapTo[Committed].map(_ => Done)
+    override def commit(batch: CommittableOffsetBatch): Future[Done] = batch match {
+      case b: CommittableOffsetBatchImpl =>
+        val futures = b.offsets.groupBy(_._1.groupId).map {
+          case (groupId, offsetsMap) =>
+            val committer = b.stages.getOrElse(
+              groupId,
+              throw new IllegalStateException(s"Unknown committer, got [$groupId]")
+            )
+            val offsets: Seq[PartitionOffset] = offsetsMap.map {
+              case (ctp, offset) => PartitionOffset(ctp, offset)
+            }(breakOut)
+            committer.commit(offsets)
+        }
+        Future.sequence(futures).map(_ => Done)
+
+      case _ => throw new IllegalArgumentException(
+        s"Unknow CommittableOffsetBatch, got [${batch.getClass.getName}], " +
+          s"expected [${classOf[CommittableOffsetBatchImpl].getName}]"
+      )
     }
   }
 
@@ -141,12 +156,13 @@ private[kafka] object ConsumerStage {
 
   final case class CommittableOffsetImpl(override val partitionOffset: ConsumerMessage.PartitionOffset)(val committer: Committer)
       extends CommittableOffset {
-    override def commitScaladsl(): Future[Done] = committer.commit(partitionOffset)
+    override def commitScaladsl(): Future[Done] = committer.commit(Seq(partitionOffset))
     override def commitJavadsl(): CompletionStage[Done] = commitScaladsl().toJava
   }
 
   trait Committer {
-    def commit(offset: PartitionOffset): Future[Done]
+    // Commit all offsets (of different topics) belonging to the same stage
+    def commit(offsets: Seq[PartitionOffset]): Future[Done]
     def commit(batch: CommittableOffsetBatch): Future[Done]
   }
 

--- a/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
@@ -341,7 +341,7 @@ class ConsumerTest(_system: ActorSystem)
   }
 
   //FIXME looks like current implementation of batch committer is incorrect
-  ignore should "support commit batching from more than one stage" in {
+  it should "support commit batching from more than one stage" in {
     assertAllStagesStopped {
       val commitLog1 = new ConsumerMock.LogHandler()
       val commitLog2 = new ConsumerMock.LogHandler()


### PR DESCRIPTION
https://github.com/akka/reactive-kafka/issues/284

Change `KafkaAsyncConsumerCommitterRef` to send the `PartitionOffset` to the right stage when batch committing.

One drawback of this solution is that the `KafkaAsyncConsumerCommitterRef` is tied to `CommittableOffsetBatchImpl`. To decouple them the `CommittableOffsetBatch` trait should be changed to return also the `Committer` for each `GroupPartitionTopic`, but since the `Committer` is part of the internal API I didn't want to make it public by exposing it.