### PR TITLE
Fixes for Akka 2.5 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,7 @@ val kafkaVersion = "0.10.2.0"
 val kafkaClients = "org.apache.kafka" % "kafka-clients" % kafkaVersion
 
 val commonDependencies = Seq(
-  "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-contrib" % "0.6" % Test
+  "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test
 )
 
 val coreDependencies = Seq(

--- a/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
@@ -17,7 +17,7 @@ import akka.stream._
 import akka.stream.scaladsl._
 import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.TestKit
-import akka.stream.contrib.TestKit.assertAllStagesStopped
+import akka.kafka.test.Utils._
 
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
@@ -67,6 +67,7 @@ class ConsumerTest(_system: ActorSystem)
   }
 
   implicit val m = ActorMaterializer(ActorMaterializerSettings(_system).withFuzzing(true))
+  implicit val stageStoppingTimeout = StageStoppingTimeout(15.seconds)
   implicit val ec = _system.dispatcher
   val messages = (1 to 10000).map(createMessage)
 

--- a/core/src/test/scala/akka/kafka/internal/ProducerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ProducerTest.scala
@@ -19,7 +19,7 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.scaladsl.Flow
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.testkit.TestKit
-import akka.stream.contrib.TestKit.assertAllStagesStopped
+import akka.kafka.test.Utils._
 
 import org.apache.kafka.clients.producer.{
   Callback,
@@ -51,7 +51,7 @@ class ProducerTest(_system: ActorSystem)
   implicit val m = ActorMaterializer(
     ActorMaterializerSettings(_system).withFuzzing(true)
   )
-
+  implicit val stageStoppingTimeout = StageStoppingTimeout(15.seconds)
   implicit val ec = _system.dispatcher
 
   type K = String

--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -7,11 +7,10 @@ package akka.kafka.scaladsl
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-
+import akka.kafka.test.Utils._
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.language.postfixOps
-
 import akka.{Done, NotUsed}
 import akka.actor.ActorSystem
 import akka.kafka.Subscriptions.TopicSubscription
@@ -20,34 +19,23 @@ import akka.kafka.ConsumerMessage.CommittableOffsetBatch
 import akka.kafka.ProducerMessage
 import akka.kafka.ProducerMessage.Message
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Keep, Source, Sink}
+import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.TestSink
 import akka.stream.testkit.TestSubscriber
 import akka.testkit.TestKit
-import akka.stream.contrib.TestKit.assertAllStagesStopped
-
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.apache.kafka.common.serialization.{
-  ByteArrayDeserializer,
-  ByteArraySerializer,
-  StringDeserializer,
-  StringSerializer
-}
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer, StringDeserializer, StringSerializer}
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.{
-  BeforeAndAfterAll,
-  BeforeAndAfterEach,
-  Matchers,
-  WordSpecLike
-}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
 import org.scalatest.Assertions
 
 class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
     with WordSpecLike with Matchers with BeforeAndAfterAll
     with BeforeAndAfterEach with TypeCheckedTripleEquals {
 
+  implicit val stageStoppingTimeout = StageStoppingTimeout(15.seconds)
   implicit val mat = ActorMaterializer()(system)
   implicit val ec = system.dispatcher
   implicit val embeddedKafkaConfig = EmbeddedKafkaConfig(9092, 2181)

--- a/core/src/test/scala/akka/kafka/test/Utils.scala
+++ b/core/src/test/scala/akka/kafka/test/Utils.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.kafka.test
+
+import akka.actor.{ActorRef, ActorRefWithCell, ActorSystem}
+import akka.stream.Materializer
+import akka.stream.impl.StreamSupervisor
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NoStackTrace
+import scala.language.reflectiveCalls
+
+object Utils {
+
+  /** Sets the default-mailbox to the usual [[akka.dispatch.UnboundedMailbox]] instead of [[StreamTestDefaultMailbox]]. */
+  val UnboundedMailboxConfig = ConfigFactory.parseString("""akka.actor.default-mailbox.mailbox-type = "akka.dispatch.UnboundedMailbox"""")
+
+  case class TE(message: String) extends RuntimeException(message) with NoStackTrace
+  final case class StageStoppingTimeout(time: FiniteDuration)
+
+  /** Compatibility between 2.4 and 2.5 */
+  type ActorMaterializerImpl = {
+    def system: ActorSystem
+    def supervisor: ActorRef
+  }
+
+  def assertAllStagesStopped[T](block: ⇒ T)(implicit timeout: StageStoppingTimeout, materializer: Materializer): T = {
+    val impl = materializer.asInstanceOf[ActorMaterializerImpl] // refined type, will never fail
+    val probe = TestProbe()(impl.system)
+    probe.send(impl.supervisor, StreamSupervisor.StopChildren)
+    probe.expectMsg(StreamSupervisor.StoppedChildren)
+    val result = block
+    probe.within(timeout.time) {
+      var children = Set.empty[ActorRef]
+      try probe.awaitAssert {
+        impl.supervisor.tell(StreamSupervisor.GetChildren, probe.ref)
+        children = probe.expectMsgType[StreamSupervisor.Children].children
+        assert(
+          children.isEmpty,
+          s"expected no StreamSupervisor children, but got [${children.mkString(", ")}]"
+        )
+      }
+      catch {
+        case ex: Throwable ⇒
+          children.foreach(_ ! StreamSupervisor.PrintDebugDump)
+          throw ex
+      }
+    }
+    result
+  }
+
+  def assertDispatcher(ref: ActorRef, dispatcher: String): Unit = ref match {
+    case r: ActorRefWithCell ⇒
+      if (r.underlying.props.dispatcher != dispatcher)
+        throw new AssertionError(s"Expected $ref to use dispatcher [$dispatcher], yet used: [${r.underlying.props.dispatcher}]")
+    case _ ⇒
+      throw new Exception(s"Unable to determine dispatcher of $ref")
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
This PR removes dependency on akka-stream-contrib and fixes some callback handling to make the library work well with Akka 2.5.0.