### PR TITLE
Optimize KafkaConsumerActor polling for committablePartitionedSource, #292

### DIFF
--- a/docs/src/test/scala/sample/scaladsl/AtLeastOnce.scala
+++ b/docs/src/test/scala/sample/scaladsl/AtLeastOnce.scala
@@ -25,7 +25,7 @@ object AtLeastOnceOneToManyExample extends ConsumerExample {
           ))
         .via(Producer.flow(producerSettings))
         .map(_.message.passThrough)
-        .collect{case Some(offset) => offset}
+        .collect{ case Some(offset) => offset }
         .batch(max = 20, CommittableOffsetBatch.empty.updated(_))(_.updated(_))
         .mapAsync(3)(_.commitScaladsl())
         .runWith(Sink.ignore)


### PR DESCRIPTION
* When using many requestors with one KafkaConsumerActor each
  RequestMessages and Commit triggered a poll, and it didn't scale
* By collecting more requests/commits before performing the poll the
  performance is improved drasticilly.
  That is done by sending a message to self, and thereby collect
  pending messages in mailbox.
* Used this benchmark for testing:
  https://github.com/agadek/reactiveKafkaBenchmark/pull/1
* Note that the commits were also a major part of the problem,
  and that was solved in the same way, which is now possible since
  https://issues.apache.org/jira/browse/KAFKA-3412 is fixed.

Refs #292