### PR TITLE
Issue 290:  Sub source of plainPartitionedSource doesn't complete when its partition gets revoked

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -133,6 +133,7 @@ private[kafka] abstract class SubSourceLogic[K, V, Msg](
         var buffer: Iterator[ConsumerRecord[K, V]] = Iterator.empty
 
         override def preStart(): Unit = {
+          super.preStart()
           subsourceStartedCB.invoke((tp, this))
           self = getStageActor {
             case (_, msg: KafkaConsumerActor.Internal.Messages[K, V]) =>


### PR DESCRIPTION
[#290](https://github.com/akka/reactive-kafka/issues/290)

* Sub sources of plainPartitionedSource didn't shutdown
  when their partitions got revoked due to control callback
  not being initialized.
* By adding superclass preStart() method call in SubSourceStage
  the control callback initalizes properly.