### PR TITLE
Issue 267: Expose offsetsForTimes function from kafkaConsumer

### DIFF
--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -111,7 +111,7 @@ object Subscriptions {
   /**
    * Manually assign given topics and partitions with offsets
    */
-  def assignementOffsetsForTimes(tp: TopicPartition, offset: Long): ManualSubscription = assignementOffsetsForTimes(Map(tp -> offset))
+  def assignementOffsetsForTimes(tp: TopicPartition, timestamp: Long): ManualSubscription = assignementOffsetsForTimes(Map(tp -> timestamp))
 
 }
 

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -28,7 +28,7 @@ object Subscriptions {
   private[kafka] final case class TopicSubscriptionPattern(pattern: String) extends AutoSubscription
   private[kafka] final case class Assignment(tps: Set[TopicPartition]) extends ManualSubscription
   private[kafka] final case class AssignmentWithOffset(tps: Map[TopicPartition, Long]) extends ManualSubscription
-  private[kafka] final case class AssignementOffsetsForTimes(timestampsToSearch: Map[TopicPartition, Long]) extends ManualSubscription
+  private[kafka] final case class AssignmentOffsetsForTimes(timestampsToSearch: Map[TopicPartition, Long]) extends ManualSubscription
 
   /**
    * Creates subscription for given set of topics
@@ -95,23 +95,23 @@ object Subscriptions {
   /**
    * Manually assign given topics and partitions with offsets
    */
-  def assignementOffsetsForTimes(tps: Map[TopicPartition, Long]): ManualSubscription = AssignementOffsetsForTimes(tps)
+  def assignmentOffsetsForTimes(tps: Map[TopicPartition, Long]): ManualSubscription = AssignmentOffsetsForTimes(tps)
 
   /**
    * Manually assign given topics and partitions with offsets
    */
-  def assignementOffsetsForTimes(tps: (TopicPartition, Long)*): ManualSubscription = AssignementOffsetsForTimes(tps.toMap)
+  def assignmentOffsetsForTimes(tps: (TopicPartition, Long)*): ManualSubscription = AssignmentOffsetsForTimes(tps.toMap)
 
   /**
    * Manually assign given topics and partitions with offsets
    * JAVA API
    */
-  def assignementOffsetsForTimes(tps: java.util.Map[TopicPartition, Long]): ManualSubscription = assignementOffsetsForTimes(tps.asScala.toMap)
+  def assignmentOffsetsForTimes(tps: java.util.Map[TopicPartition, Long]): ManualSubscription = assignmentOffsetsForTimes(tps.asScala.toMap)
 
   /**
    * Manually assign given topics and partitions with offsets
    */
-  def assignementOffsetsForTimes(tp: TopicPartition, timestamp: Long): ManualSubscription = assignementOffsetsForTimes(Map(tp -> timestamp))
+  def assignmentOffsetsForTimes(tp: TopicPartition, timestamp: Long): ManualSubscription = assignmentOffsetsForTimes(Map(tp -> timestamp))
 
 }
 

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -28,6 +28,7 @@ object Subscriptions {
   private[kafka] final case class TopicSubscriptionPattern(pattern: String) extends AutoSubscription
   private[kafka] final case class Assignment(tps: Set[TopicPartition]) extends ManualSubscription
   private[kafka] final case class AssignmentWithOffset(tps: Map[TopicPartition, Long]) extends ManualSubscription
+  private[kafka] final case class AssignementOffsetsForTimes(timestampsToSearch: Map[TopicPartition, Long]) extends ManualSubscription
 
   /**
    * Creates subscription for given set of topics
@@ -90,6 +91,28 @@ object Subscriptions {
    * Manually assign given topics and partitions with offsets
    */
   def assignmentWithOffset(tp: TopicPartition, offset: Long): ManualSubscription = assignmentWithOffset(Map(tp -> offset))
+
+  /**
+   * Manually assign given topics and partitions with offsets
+   */
+  def assignementOffsetsForTimes(tps: Map[TopicPartition, Long]): ManualSubscription = assignementOffsetsForTimes(tps)
+
+  /**
+   * Manually assign given topics and partitions with offsets
+   */
+  def assignementOffsetsForTimes(tps: (TopicPartition, Long)*): ManualSubscription = assignementOffsetsForTimes(tps.toMap)
+
+  /**
+   * Manually assign given topics and partitions with offsets
+   * JAVA API
+   */
+  def assignementOffsetsForTimes(tps: java.util.Map[TopicPartition, Long]): ManualSubscription = assignementOffsetsForTimes(tps.asScala.toMap)
+
+  /**
+   * Manually assign given topics and partitions with offsets
+   */
+  def assignementOffsetsForTimes(tp: TopicPartition, offset: Long): ManualSubscription = assignementOffsetsForTimes(Map(tp -> offset))
+
 }
 
 object ConsumerSettings {

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -95,12 +95,12 @@ object Subscriptions {
   /**
    * Manually assign given topics and partitions with offsets
    */
-  def assignementOffsetsForTimes(tps: Map[TopicPartition, Long]): ManualSubscription = assignementOffsetsForTimes(tps)
+  def assignementOffsetsForTimes(tps: Map[TopicPartition, Long]): ManualSubscription = AssignementOffsetsForTimes(tps)
 
   /**
    * Manually assign given topics and partitions with offsets
    */
-  def assignementOffsetsForTimes(tps: (TopicPartition, Long)*): ManualSubscription = assignementOffsetsForTimes(tps.toMap)
+  def assignementOffsetsForTimes(tps: (TopicPartition, Long)*): ManualSubscription = AssignementOffsetsForTimes(tps.toMap)
 
   /**
    * Manually assign given topics and partitions with offsets

--- a/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
@@ -26,6 +26,7 @@ object KafkaConsumerActor {
     //requests
     final case class Assign(tps: Set[TopicPartition])
     final case class AssignWithOffset(tps: Map[TopicPartition, Long])
+    final case class AssignOffsetsForTimes(timestampsToSearch: Map[TopicPartition, Long])
     final case class Subscribe(topics: Set[String], listener: ConsumerRebalanceListener)
     final case class SubscribePattern(pattern: String, listener: ConsumerRebalanceListener)
     final case class RequestMessages(requestId: Int, topics: Set[TopicPartition])
@@ -102,6 +103,19 @@ private[kafka] class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V])
       consumer.assign((tps.keys.toSeq ++ previousAssigned.asScala).asJava)
       tps.foreach {
         case (tp, offset) => consumer.seek(tp, offset)
+      }
+    case AssignOffsetsForTimes(timestampsToSearch) =>
+      scheduleFirstPollTask()
+      checkOverlappingRequests("AssignOffsetsForTimes", sender(), timestampsToSearch.keySet)
+      val previousAssigned = consumer.assignment()
+      consumer.assign((timestampsToSearch.keys.toSeq ++ previousAssigned.asScala).asJava)
+      val topicPartitionToOffsetAndTimestamp = consumer.offsetsForTimes(timestampsToSearch.mapValues(long2Long(_)).asJava)
+      topicPartitionToOffsetAndTimestamp.asScala.foreach {
+        case (tp, oat: OffsetAndTimestamp) =>
+          val offset = oat.offset()
+          val ts = oat.timestamp()
+          log.debug("Get offset {} from topic {} with timestamp {}", offset, tp, ts)
+          consumer.seek(tp, offset)
       }
 
     case Commit(offsets) =>

--- a/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
@@ -5,7 +5,7 @@
 package akka.kafka.internal
 
 import akka.actor.{ActorRef, Terminated}
-import akka.kafka.Subscriptions.{AssignementOffsetsForTimes, Assignment, AssignmentWithOffset}
+import akka.kafka.Subscriptions.{AssignmentOffsetsForTimes, Assignment, AssignmentWithOffset}
 import akka.kafka.{KafkaConsumerActor, ManualSubscription}
 import akka.stream.SourceShape
 import akka.stream.stage.GraphStageLogic.StageActor
@@ -54,7 +54,7 @@ private[kafka] abstract class ExternalSingleSourceLogic[K, V, Msg](
       case AssignmentWithOffset(topics) =>
         consumer.tell(KafkaConsumerActor.Internal.AssignWithOffset(topics), self.ref)
         tps ++= topics.keySet
-      case AssignementOffsetsForTimes(topics) =>
+      case AssignmentOffsetsForTimes(topics) =>
         consumer.tell(KafkaConsumerActor.Internal.AssignOffsetsForTimes(topics), self.ref)
         tps ++= topics.keySet
     }

--- a/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
@@ -5,7 +5,7 @@
 package akka.kafka.internal
 
 import akka.actor.{ActorRef, Terminated}
-import akka.kafka.Subscriptions.{Assignment, AssignmentWithOffset}
+import akka.kafka.Subscriptions.{AssignementOffsetsForTimes, Assignment, AssignmentWithOffset}
 import akka.kafka.{KafkaConsumerActor, ManualSubscription}
 import akka.stream.SourceShape
 import akka.stream.stage.GraphStageLogic.StageActor
@@ -53,6 +53,9 @@ private[kafka] abstract class ExternalSingleSourceLogic[K, V, Msg](
         tps ++= topics
       case AssignmentWithOffset(topics) =>
         consumer.tell(KafkaConsumerActor.Internal.AssignWithOffset(topics), self.ref)
+        tps ++= topics.keySet
+      case AssignementOffsetsForTimes(topics) =>
+        consumer.tell(KafkaConsumerActor.Internal.AssignOffsetsForTimes(topics), self.ref)
         tps ++= topics.keySet
     }
   }

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -5,7 +5,7 @@
 package akka.kafka.internal
 
 import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
-import akka.kafka.Subscriptions.{Assignment, AssignmentWithOffset, TopicSubscription, TopicSubscriptionPattern}
+import akka.kafka.Subscriptions._
 import akka.kafka.{ConsumerSettings, KafkaConsumerActor, Subscription}
 import akka.stream.stage.GraphStageLogic.StageActor
 import akka.stream.stage.{GraphStageLogic, OutHandler}
@@ -78,6 +78,9 @@ private[kafka] abstract class SingleSourceLogic[K, V, Msg](
         tps ++= topics
       case AssignmentWithOffset(topics) =>
         consumer.tell(KafkaConsumerActor.Internal.AssignWithOffset(topics), self.ref)
+        tps ++= topics.keySet
+      case AssignementOffsetsForTimes(topics) =>
+        consumer.tell(KafkaConsumerActor.Internal.AssignOffsetsForTimes(topics), self.ref)
         tps ++= topics.keySet
     }
 

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -79,7 +79,7 @@ private[kafka] abstract class SingleSourceLogic[K, V, Msg](
       case AssignmentWithOffset(topics) =>
         consumer.tell(KafkaConsumerActor.Internal.AssignWithOffset(topics), self.ref)
         tps ++= topics.keySet
-      case AssignementOffsetsForTimes(topics) =>
+      case AssignmentOffsetsForTimes(topics) =>
         consumer.tell(KafkaConsumerActor.Internal.AssignOffsetsForTimes(topics), self.ref)
         tps ++= topics.keySet
     }

--- a/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
+++ b/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
@@ -100,6 +100,27 @@ object ExternalOffsetStorageExample extends ConsumerExample {
   }
 }
 
+// Consume messages and store a representation, including offset extract from timestamp, in DB
+object ExternalOffsetStorageExampleWithTimes extends ConsumerExample {
+  def main(args: Array[String]): Unit = {
+    // #plainSource
+    val db = new DB
+    db.loadOffset().foreach { fromLongTime =>
+      val partition = 0
+      val subscription = Subscriptions.assignementOffsetsForTimes(
+        new TopicPartition("topic1", partition) -> fromLongTime
+      )
+      val done =
+        Consumer.plainSource(consumerSettings, subscription)
+          .mapAsync(1)(db.save)
+          .runWith(Sink.ignore)
+      // #plainSource
+
+      terminateWhenDone(done)
+    }
+  }
+}
+
 // Consume messages at-most-once
 object AtMostOnceExample extends ConsumerExample {
   def main(args: Array[String]): Unit = {

--- a/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
+++ b/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
@@ -107,7 +107,7 @@ object ExternalOffsetStorageExampleWithTimes extends ConsumerExample {
     val db = new DB
     db.loadOffset().foreach { fromLongTime =>
       val partition = 0
-      val subscription = Subscriptions.assignementOffsetsForTimes(
+      val subscription = Subscriptions.assignmentOffsetsForTimes(
         new TopicPartition("topic1", partition) -> fromLongTime
       )
       val done =


### PR DESCRIPTION
You can use this to get topic/partitions offsets from a timestamp (i.e Kafka timestamp https://cwiki.apache.org/confluence/display/KAFKA/KIP-32+-+Add+timestamps+to+Kafka+message) to setup the initial position in kafka when starting the stream. This will work without auto-rebalance if you plan to manage your offset manually. 

Discussion on #267 