### PR TITLE
Fix the "At-Least-Once Delivery" link

### DIFF
--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -110,7 +110,7 @@ Java
 : @@ snip [dummy](../../test/java/sample/javadsl/ConsumerExample.java) { #atMostOnce }
 
 Maintaining at-least-once delivery semantics requires care, so many risks and solutions
-are covered in [At-Least-Once Delivery](atleastonce.md).
+are covered in @ref:[At-Least-Once Delivery](atleastonce.md).
 
 ## Connecting Producer and Consumer
 


### PR DESCRIPTION
Right now, the link on http://doc.akka.io/docs/akka-stream-kafka/current/consumer.html points to http://doc.akka.io/docs/akka-stream-kafka/current/atleastonce.md, which returns 404.

Paradox requires the `@ref:` prefix when linking to a local Markdown document, so that it will rewrite the file extension to `.html` when building the site.

The new page is great. Thanks, @patrick-premont!