### PR TITLE
Discard unsent ProducerRecords after encountering a send-failure in ProducerStage #295

### DIFF
--- a/core/src/test/scala/akka/kafka/internal/ProducerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ProducerTest.scala
@@ -13,7 +13,7 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.kafka.ProducerMessage._
 import akka.kafka.ProducerSettings
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
+import akka.stream.{ActorAttributes, ActorMaterializer, ActorMaterializerSettings, Supervision}
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.scaladsl.Flow
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
@@ -22,6 +22,7 @@ import akka.kafka.test.Utils._
 import org.apache.kafka.clients.producer.{Callback, KafkaProducer, ProducerRecord, RecordMetadata}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringSerializer
+import org.mockito
 import org.mockito.Matchers._
 import org.mockito.Mockito
 import Mockito._
@@ -60,6 +61,11 @@ class ProducerTest(_system: ActorSystem)
   def toMessage(tuple: (Record, RecordMetadata)) = Message(tuple._1, NotUsed)
   def result(r: Record, m: RecordMetadata) = Result(m, Message(r, NotUsed))
   val toResult = (result _).tupled
+
+  def recordValues(values: V*): ((ProducerRecord[String, String], RecordMetadata)) => Boolean = {
+    case (r, _) =>
+      values.contains(r.value())
+  }
 
   val settings = ProducerSettings(system, new StringSerializer, new StringSerializer)
 
@@ -138,7 +144,7 @@ class ProducerTest(_system: ActorSystem)
     client.verifyNoMoreInteractions()
   }
 
-  it should "fail stream in case of fail to send message" in {
+  it should "fail stream and force-close producer in callback on send failure" in {
     assertAllStagesStopped {
       val input = 1 to 3 map recordAndMetadata
       val error = new Exception("Something wrong in kafka")
@@ -160,6 +166,87 @@ class ProducerTest(_system: ActorSystem)
       input.map(toMessage).foreach(source.sendNext)
 
       source.expectCancellation()
+
+      client.verifyForceClosedInCallback()
+      client.verifySend(atLeastOnce())
+      client.verifyNoMoreInteractions()
+    }
+  }
+
+  it should "stop emitting messages after encountering a send failure" in {
+    assertAllStagesStopped {
+      val input = 1 to 3 map recordAndMetadata
+      val error = new Exception("Something wrong in kafka")
+
+      val client = {
+        val inputMap = input.toMap
+        new ProducerMock[K, V](ProducerMock.handlers.delayedMap(100.millis) { msg =>
+          if (msg.value() == "2") Failure(error)
+          else Success(inputMap(msg))
+        })
+      }
+      val (source, sink) = TestSource
+        .probe[Msg]
+        .via(testProducerFlow(client))
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      input.map(toMessage).foreach(source.sendNext)
+
+      sink.request(100)
+        .expectNextN(input.filter(recordValues("1")).map(toResult))
+        .expectError(error)
+
+      source.expectCancellation()
+
+      client.verifyForceClosedInCallback()
+      client.verifySend(atLeastOnce())
+      client.verifyNoMoreInteractions()
+    }
+  }
+
+  it should "resume stream and gracefully close producer on send failure if specified by supervision-strategy" in {
+    assertAllStagesStopped {
+      val input = 1 to 3 map recordAndMetadata
+      val error = new Exception("Something wrong in kafka")
+
+      val client = {
+        val inputMap = input.toMap
+        new ProducerMock[K, V](ProducerMock.handlers.delayedMap(100.millis) { msg =>
+          if (msg.value() == "2") Failure(error)
+          else Success(inputMap(msg))
+        })
+      }
+      val (source, sink) = TestSource
+        .probe[Msg]
+        .via(testProducerFlow(client).withAttributes(ActorAttributes.withSupervisionStrategy(Supervision.resumingDecider)))
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      input.map(toMessage).foreach(source.sendNext)
+      source.sendComplete()
+
+      sink.request(100)
+        .expectNextN(input.filter(recordValues("1", "3")).map(toResult))
+        .expectComplete()
+
+      client.verifyClosed()
+      client.verifySend(atLeastOnce())
+      client.verifyNoMoreInteractions()
+    }
+  }
+
+  it should "fail stream on exception of producer send" in {
+    assertAllStagesStopped {
+      val input = 1 to 3 map recordAndMetadata
+
+      val client = new ProducerMock[K, V](ProducerMock.handlers.fail)
+      val probe = Source(input.map(toMessage))
+        .via(testProducerFlow(client))
+        .runWith(TestSink.probe)
+
+      probe.request(10)
+        .expectError()
 
       client.verifyClosed()
       client.verifySend(atLeastOnce())
@@ -265,6 +352,13 @@ class ProducerMock[K, V](handler: ProducerMock.Handler[K, V])(implicit ec: Execu
   def verifyClosed() = {
     Mockito.verify(mock).flush()
     Mockito.verify(mock).close(any[Long], any[TimeUnit])
+  }
+
+  def verifyForceClosedInCallback() = {
+    val inOrder = Mockito.inOrder(mock)
+    inOrder.verify(mock, atLeastOnce()).close(mockito.Matchers.eq(0L), any[TimeUnit])
+    inOrder.verify(mock).flush()
+    inOrder.verify(mock).close(any[Long], any[TimeUnit])
   }
 
   def verifyNoMoreInteractions() = {


### PR DESCRIPTION
* The `Supervision.Stop`-behaviour of the `ProducerStage` flushed all unsent `ProducerRecord`s
queued in the `KafkaProducer`s send-buffer when encountering a send-failure, regardless of their
chronological order in relation to the failed `ProducerRecord`.
As the stream was shutdown after encountering the failure, these `ProducerRecord`s were produced
to Kafka but could never be observed on stages downstream.
This situation lead to a non-deterministic failure-behaviour where a client could not be sure which
`ProducerRecord`s were actually produced to Kafka after encountering a send-failure.
This behaviour also lead to message-reordering in regards to the message-source, as failing
`ProducerRecord`s were dropped but subsequent `ProducerRecord`s were produced to Kafka.

* Introduce deterministic failure-behaviour by closing the `KafkaProducer` in the send-callback
upon encountering a send-failure. This behaviour ensures that no `ProducerRecord` is sent to Kafka
which was scheduled after the failed `ProducerRecord`.

* Apply the new failure-behaviour only if the `ProducerStage` is stopped by the send-failure,
determined by the given `SupervisionStrategy`.

Refs #295

Lightbend-CLA has been signed.