### PR TITLE
Expose metrics via Control

### DIFF
--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -16,11 +16,12 @@ import akka.kafka.{AutoSubscription, ConsumerSettings, ManualSubscription, Subsc
 import akka.stream.javadsl.Source
 import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
 import scala.compat.java8.FutureConverters
+import scala.concurrent.Future
 
 /**
  * Akka Stream connector for subscribing to Kafka topics.
@@ -52,6 +53,12 @@ object Consumer {
      * from downstream cancellation, errors, or [[#shutdown]].
      */
     def isShutdown: CompletionStage[Done]
+
+    /**
+     * Exposes underlying consumer or producer metrics (as reported by underlying Kafka client library)
+     */
+    def getMetrics: CompletionStage[java.util.Map[MetricName, Metric]]
+
   }
 
   /**

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -13,7 +13,7 @@ import akka.kafka.{AutoSubscription, ConsumerSettings, ManualSubscription, Subsc
 import akka.stream.scaladsl.Source
 import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -48,6 +48,11 @@ object Consumer {
      * from downstream cancellation, errors, or [[#shutdown]].
      */
     def isShutdown: Future[Done]
+
+    /**
+     * Exposes underlying consumer or producer metrics (as reported by underlying Kafka client library)
+     */
+    def metrics: Future[Map[MetricName, Metric]]
   }
 
   /**

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -177,4 +177,12 @@ Java
 : @@ snip [consumerToProducerSink](../../test/java/sample/javadsl/ConsumerExample.java) { #consumerActor }
 
 
+## Accessing KafkaConsumer metrics
 
+You can access the underlying consumer metrics by `ask`-ing the `KafkaConsumerActor` for them: 
+
+Scala
+: @@ snip [consumerMetrics](../../test/scala/sample/scaladsl/ConsumerExample.scala) { #consumerMetrics }
+
+Java
+: @@ snip [consumerMetrics](../../test/java/sample/javadsl/ConsumerExample.java) { #consumerMetrics }

--- a/docs/src/main/paradox/producer.md
+++ b/docs/src/main/paradox/producer.md
@@ -85,3 +85,14 @@ Scala
 
 Java
 : @@ snip [plainSinkWithProducer](../../test/java/sample/javadsl/ProducerExample.java) { #plainSinkWithProducer }
+
+## Accessing KafkaProducer metrics
+
+As it is possible to share an existing `KafkaProducer` (as shown in the previous section),
+accessing its metrics is fairly simple:
+
+Scala
+: @@ snip [plainSinkWithProducer](../../test/scala/sample/scaladsl/ProducerExample.scala) { #producerMetrics }
+
+Java
+: @@ snip [plainSinkWithProducer](../../test/java/sample/javadsl/ProducerExample.java) { #producerMetrics }

--- a/docs/src/test/java/sample/javadsl/ProducerExample.java
+++ b/docs/src/test/java/sample/javadsl/ProducerExample.java
@@ -79,6 +79,18 @@ class PlainSinkWithProducerExample extends ProducerExample {
     }
 }
 
+class ObserveMetricsExample extends ProducerExample {
+    public static void main(String[] args) {
+        new PlainSinkExample().demo();
+    }
+
+    public void demo() {
+        // #producerMetrics
+        kafkaProducer.metrics(); // observe metrics
+        // #producerMetrics
+    }
+}
+
 class ProducerFlowExample extends ProducerExample {
   public static void main(String[] args) {
     new ProducerFlowExample().demo();

--- a/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
+++ b/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
@@ -373,17 +373,13 @@ object ConsumerMetrics extends ConsumerExample {
     val consumer: ActorRef = system.actorOf(KafkaConsumerActor.props(consumerSettings))
 
     // use the consumer actor manually in streams:
-    Consumer
+    val control: Consumer.Control = Consumer
       .plainExternalSource[Array[Byte], String](consumer, Subscriptions.assignment(new TopicPartition("topic1", 1)))
       .via(business)
-      .runWith(Sink.ignore)
+      .to(Sink.ignore)
+      .run()
 
-    // Obtain a single metric Map by asking the consumer actor directly:
-    import KafkaConsumerActor._
-    implicit val t = Timeout(1.second)
-
-    val metrics: Future[ConsumerMetrics] = (consumer ? RequestMetrics).mapTo[ConsumerMetrics]
-    metrics foreach { m ⇒ println(s"Metrics: " + m.metrics) }
+    println(s"metrics: ${control.metrics}")
     // #consumerMetrics
   }
 }

--- a/docs/src/test/scala/sample/scaladsl/ProducerExample.scala
+++ b/docs/src/test/scala/sample/scaladsl/ProducerExample.scala
@@ -72,6 +72,14 @@ object PlainSinkWithProducerExample extends ProducerExample {
   }
 }
 
+object ObserveMetricsExample extends ProducerExample {
+  def main(args: Array[String]): Unit = {
+    // #producerMetrics
+    kafkaProducer.metrics() // observe metrics
+    // #producerMetrics
+  }
+}
+
 object ProducerFlowExample extends ProducerExample {
   def main(args: Array[String]): Unit = {
     // #flow


### PR DESCRIPTION
We'd like to be able to expose metrics to users when they use the Sharing the Consumer Actor pattern; I thought this style would likely be good enough - I assume the same could be done in the Publisher?