### PR TITLE
Expose offsetsForTimes function from kafkaConsumer with auto rebalance

### DIFF
--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -24,10 +24,29 @@ sealed trait ManualSubscription extends Subscription
 sealed trait AutoSubscription extends Subscription
 
 object Subscriptions {
+  private[kafka] final case class TopicSubscriptionWithStartTimestamp(timestamp: Long, tps: Set[String]) extends AutoSubscription
   private[kafka] final case class TopicSubscription(tps: Set[String]) extends AutoSubscription
   private[kafka] final case class TopicSubscriptionPattern(pattern: String) extends AutoSubscription
   private[kafka] final case class Assignment(tps: Set[TopicPartition]) extends ManualSubscription
   private[kafka] final case class AssignmentWithOffset(tps: Map[TopicPartition, Long]) extends ManualSubscription
+
+  /**
+   * Creates subscription for given set of topics
+   */
+  def topicsWithTimestamp(timestamp: Long, ts: Set[String]): AutoSubscription = TopicSubscriptionWithStartTimestamp(timestamp, ts)
+
+  /**
+   * Creates subscription for given set of topics
+   * JAVA API
+   */
+  @varargs
+  def topics(timestamp: Long, ts: String*): AutoSubscription = topicsWithTimestamp(timestamp, ts.toSet)
+
+  /**
+   * Creates subscription for given set of topics
+   * JAVA API
+   */
+  def topics(timestamp: Long, ts: java.util.Set[String]): AutoSubscription = topicsWithTimestamp(timestamp, ts.asScala.toSet)
 
   /**
    * Creates subscription for given set of topics

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -5,7 +5,7 @@
 package akka.kafka.internal
 
 import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
-import akka.kafka.Subscriptions.{Assignment, AssignmentWithOffset, TopicSubscription, TopicSubscriptionPattern}
+import akka.kafka.Subscriptions._
 import akka.kafka.{ConsumerSettings, KafkaConsumerActor, Subscription}
 import akka.stream.stage.GraphStageLogic.StageActor
 import akka.stream.stage.{GraphStageLogic, OutHandler}
@@ -69,6 +69,8 @@ private[kafka] abstract class SingleSourceLogic[K, V, Msg](
       KafkaConsumerActor.rebalanceListener(partitionAssignedCB.invoke, partitionRevokedCB.invoke)
 
     subscription match {
+      case TopicSubscriptionWithStartTimestamp(timestamp, topics) =>
+        consumer.tell(KafkaConsumerActor.Internal.SubscribeWithStartTimestamp(timestamp, topics, rebalanceListener), self.ref)
       case TopicSubscription(topics) =>
         consumer.tell(KafkaConsumerActor.Internal.Subscribe(topics, rebalanceListener), self.ref)
       case TopicSubscriptionPattern(topics) =>

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -6,7 +6,7 @@ package akka.kafka.internal
 
 import akka.NotUsed
 import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
-import akka.kafka.Subscriptions.{TopicSubscription, TopicSubscriptionPattern}
+import akka.kafka.Subscriptions.{TopicSubscription, TopicSubscriptionPattern, TopicSubscriptionWithStartTimestamp}
 import akka.kafka.scaladsl.Consumer.Control
 import akka.kafka.{AutoSubscription, ConsumerSettings, KafkaConsumerActor}
 import akka.stream.scaladsl.Source
@@ -47,6 +47,8 @@ private[kafka] abstract class SubSourceLogic[K, V, Msg](
       KafkaConsumerActor.rebalanceListener(partitionAssignedCB.invoke, partitionRevokedCB.invoke)
 
     subscription match {
+      case TopicSubscriptionWithStartTimestamp(timestamp, topics) =>
+        consumer.tell(KafkaConsumerActor.Internal.SubscribeWithStartTimestamp(timestamp, topics, rebalanceListener), self.ref)
       case TopicSubscription(topics) =>
         consumer.tell(KafkaConsumerActor.Internal.Subscribe(topics, rebalanceListener), self.ref)
       case TopicSubscriptionPattern(topics) =>


### PR DESCRIPTION
You can use this to get topic/partitions offsets from a timestamp (i.e Kafka timestamp https://cwiki.apache.org/confluence/display/KAFKA/KIP-32+-+Add+timestamps+to+Kafka+message) to setup the initial position in kafka when starting the stream. 

This will work **with auto-rebalance** if you don't want to manually manage your kafka offset commit.

Discussion on #267