### PR TITLE
Upgrade Akka to 2.4.20

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import de.heikoseeberger.sbtheader.HeaderPattern
 
 name := "akka-stream-kafka"
 
-val akkaVersion = "2.4.18"
+val akkaVersion = "2.4.20"
 val kafkaVersion = "0.11.0.0"
 
 val kafkaClients = "org.apache.kafka" % "kafka-clients" % kafkaVersion


### PR DESCRIPTION
I do not know if you planned to migrate to Akka 2.5.x... but meanwhile I propose to upgrade to the latest version in 2.4.