### PR TITLE
 Use specfic exception for Kafka commit timeout rather exposing AskException

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,10 @@ val coreDependencies = Seq(
   "junit" % "junit" % "4.12" % Test,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Test,
   "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
-  "ch.qos.logback" % "logback-classic" % "1.1.3" % Test,
-  "org.slf4j" % "log4j-over-slf4j" % "1.7.12" % Test,
-  "org.mockito" % "mockito-core" % "1.10.19" % Test,
-  "net.manub" %% "scalatest-embedded-kafka" % "0.14.0" % Test exclude("log4j", "log4j"),
+  "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,
+  "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % Test,
+  "org.mockito" % "mockito-core" % "2.10.0" % Test,
+  "net.manub" %% "scalatest-embedded-kafka" % "0.16.0" % Test exclude("log4j", "log4j"),
   "org.apache.kafka" %% "kafka" % kafkaVersion % Test exclude("org.slf4j", "slf4j-log4j12")
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,10 @@ val coreDependencies = Seq(
   "junit" % "junit" % "4.12" % Test,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Test,
   "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
-  "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,
-  "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % Test,
-  "org.mockito" % "mockito-core" % "2.10.0" % Test,
-  "net.manub" %% "scalatest-embedded-kafka" % "0.16.0" % Test exclude("log4j", "log4j"),
+  "ch.qos.logback" % "logback-classic" % "1.1.3" % Test,
+  "org.slf4j" % "log4j-over-slf4j" % "1.7.12" % Test,
+  "org.mockito" % "mockito-core" % "1.10.19" % Test,
+  "net.manub" %% "scalatest-embedded-kafka" % "0.14.0" % Test exclude("log4j", "log4j"),
   "org.apache.kafka" %% "kafka" % kafkaVersion % Test exclude("org.slf4j", "slf4j-log4j12")
 )
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -45,8 +45,11 @@ akka.kafka.consumer {
   close-timeout = 20s
   
   # If offset commit requests are not completed within this timeout
-  # the returned Future is completed `TimeoutException`.
+  # the returned Future is completed `CommitTimeoutException`.
   commit-timeout = 15s
+
+  # If commits take longer than this time a warning is logged
+  commit-time-warning = 1s
   
   # If the KafkaConsumer can't connect to the broker the poll will be
   # aborted after this timeout. The KafkaConsumerActor will throw

--- a/core/src/main/scala/akka/kafka/CommitTimeoutException.scala
+++ b/core/src/main/scala/akka/kafka/CommitTimeoutException.scala
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.kafka
+
+import java.util.concurrent.TimeoutException
+
+/**
+ * Calls to `commitJavadsl` and `commitScaladsl` will be failed with this exception if
+ * Kafka doesn't respond within `commit-timeout`
+ */
+class CommitTimeoutException(msg: String) extends TimeoutException(msg) {}

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -157,11 +157,12 @@ object ConsumerSettings {
     val stopTimeout = config.getDuration("stop-timeout", TimeUnit.MILLISECONDS).millis
     val closeTimeout = config.getDuration("close-timeout", TimeUnit.MILLISECONDS).millis
     val commitTimeout = config.getDuration("commit-timeout", TimeUnit.MILLISECONDS).millis
+    val commitTimeWarning = config.getDuration("commit-time-warning", TimeUnit.MILLISECONDS).millis
     val wakeupTimeout = config.getDuration("wakeup-timeout", TimeUnit.MILLISECONDS).millis
     val maxWakeups = config.getInt("max-wakeups")
     val dispatcher = config.getString("use-dispatcher")
     new ConsumerSettings[K, V](properties, keyDeserializer, valueDeserializer,
-      pollInterval, pollTimeout, stopTimeout, closeTimeout, commitTimeout, wakeupTimeout, maxWakeups, dispatcher)
+      pollInterval, pollTimeout, stopTimeout, closeTimeout, commitTimeout, wakeupTimeout, maxWakeups, dispatcher, commitTimeWarning)
   }
 
   /**
@@ -256,7 +257,8 @@ class ConsumerSettings[K, V](
     val commitTimeout: FiniteDuration,
     val wakeupTimeout: FiniteDuration,
     val maxWakeups: Int,
-    val dispatcher: String
+    val dispatcher: String,
+    val commitTimeWarning: FiniteDuration = 1.second
 ) {
 
   def withBootstrapServers(bootstrapServers: String): ConsumerSettings[K, V] =
@@ -295,6 +297,9 @@ class ConsumerSettings[K, V](
   def withCommitTimeout(commitTimeout: FiniteDuration): ConsumerSettings[K, V] =
     copy(commitTimeout = commitTimeout)
 
+  def withCommitWarning(commitTimeWarning: FiniteDuration): ConsumerSettings[K, V] =
+    copy(commitTimeWarning = commitTimeWarning)
+
   def withWakeupTimeout(wakeupTimeout: FiniteDuration): ConsumerSettings[K, V] =
     copy(wakeupTimeout = wakeupTimeout)
 
@@ -313,13 +318,14 @@ class ConsumerSettings[K, V](
     stopTimeout: FiniteDuration = stopTimeout,
     closeTimeout: FiniteDuration = closeTimeout,
     commitTimeout: FiniteDuration = commitTimeout,
+    commitTimeWarning: FiniteDuration = commitTimeWarning,
     wakeupTimeout: FiniteDuration = wakeupTimeout,
     maxWakeups: Int = maxWakeups,
     dispatcher: String = dispatcher
   ): ConsumerSettings[K, V] =
     new ConsumerSettings[K, V](properties, keyDeserializer, valueDeserializer,
       pollInterval, pollTimeout, stopTimeout, closeTimeout, commitTimeout, wakeupTimeout,
-      maxWakeups, dispatcher)
+      maxWakeups, dispatcher, commitTimeWarning)
 
   /**
    * Create a `KafkaConsumer` instance from the settings.

--- a/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
@@ -10,11 +10,10 @@ import java.util.{List => JList, Map => JMap, Set => JSet}
 import akka.Done
 import akka.actor.ActorSystem
 import akka.kafka.ConsumerMessage._
-import akka.kafka.ConsumerSettings
+import akka.kafka.{CommitTimeoutException, ConsumerSettings}
 import akka.kafka.Subscriptions.TopicSubscription
 import akka.kafka.scaladsl.Consumer
 import Consumer.Control
-import akka.pattern.AskTimeoutException
 import akka.stream._
 import akka.stream.scaladsl._
 import akka.stream.testkit.scaladsl.TestSink
@@ -533,7 +532,7 @@ class ConsumerTest(_system: ActorSystem)
       Await.result(stopped, remainingOrDefault)
 
       val done = first.committableOffset.commitScaladsl()
-      intercept[AskTimeoutException] {
+      intercept[CommitTimeoutException] {
         Await.result(done, remainingOrDefault)
       }
     }


### PR DESCRIPTION
* To encourage users to look at their kafka cluster before assuming it
is a bug in the library
* Add a warning threshhold at which we start logging slow kafka commits