### PR TITLE
Remove unused imports

### DIFF
--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/Benchmarks.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/Benchmarks.scala
@@ -6,11 +6,9 @@ package akka.kafka.benchmarks
 
 import akka.actor.ActorSystem
 import akka.kafka.benchmarks.app.RunTestCommand
-import akka.stream.{Materializer, ActorMaterializer}
+import akka.stream.Materializer
 import Timed._
-import com.typesafe.config.ConfigFactory
 import scala.concurrent.Future
-import scala.language.postfixOps
 
 object Benchmarks {
 

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerFixtures.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerFixtures.scala
@@ -10,7 +10,6 @@ import akka.kafka.benchmarks.app.RunTestCommand
 import akka.kafka.scaladsl.Consumer
 import akka.kafka.scaladsl.Consumer.Control
 import akka.kafka.{ConsumerSettings, Subscriptions}
-import akka.stream.ActorAttributes
 import akka.stream.scaladsl.Source
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord}
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}


### PR DESCRIPTION
this removes four warnings when compiling in Scala 2.12.x