### PR TITLE
Add specific exception type for when the Kafka Consumer Actor is terminated

### DIFF
--- a/core/src/main/scala/akka/kafka/ConsumerActorTerminatedException.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerActorTerminatedException.scala
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.kafka
+
+class ConsumerActorTerminatedException extends Exception("Consumer actor terminated")

--- a/core/src/main/scala/akka/kafka/ConsumerFailed.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerFailed.scala
@@ -4,4 +4,4 @@
  */
 package akka.kafka
 
-class ConsumerActorTerminatedException extends Exception("Consumer actor terminated")
+class ConsumerFailed extends RuntimeException("Consumer actor terminated")

--- a/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
@@ -5,8 +5,8 @@
 package akka.kafka.internal
 
 import akka.actor.{ActorRef, Terminated}
-import akka.kafka.Subscriptions.{AssignmentOffsetsForTimes, Assignment, AssignmentWithOffset}
-import akka.kafka.{KafkaConsumerActor, ManualSubscription}
+import akka.kafka.Subscriptions.{Assignment, AssignmentOffsetsForTimes, AssignmentWithOffset}
+import akka.kafka.{ConsumerActorTerminatedException, KafkaConsumerActor, ManualSubscription}
 import akka.stream.SourceShape
 import akka.stream.stage.GraphStageLogic.StageActor
 import akka.stream.stage.{GraphStageLogic, OutHandler}
@@ -43,7 +43,7 @@ private[kafka] abstract class ExternalSingleSourceLogic[K, V, Msg](
         }
         pump()
       case (_, Terminated(ref)) if ref == consumer =>
-        failStage(new Exception("Consumer actor terminated"))
+        failStage(new ConsumerActorTerminatedException)
     }
     self.watch(consumer)
 

--- a/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
@@ -6,7 +6,7 @@ package akka.kafka.internal
 
 import akka.actor.{ActorRef, Terminated}
 import akka.kafka.Subscriptions.{Assignment, AssignmentOffsetsForTimes, AssignmentWithOffset}
-import akka.kafka.{ConsumerActorTerminatedException, KafkaConsumerActor, ManualSubscription}
+import akka.kafka.{ConsumerFailed, KafkaConsumerActor, ManualSubscription}
 import akka.stream.SourceShape
 import akka.stream.stage.GraphStageLogic.StageActor
 import akka.stream.stage.{GraphStageLogic, OutHandler}
@@ -43,7 +43,7 @@ private[kafka] abstract class ExternalSingleSourceLogic[K, V, Msg](
         }
         pump()
       case (_, Terminated(ref)) if ref == consumer =>
-        failStage(new ConsumerActorTerminatedException)
+        failStage(new ConsumerFailed)
     }
     self.watch(consumer)
 

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -6,7 +6,7 @@ package akka.kafka.internal
 
 import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
 import akka.kafka.Subscriptions._
-import akka.kafka.{ConsumerSettings, KafkaConsumerActor, Subscription}
+import akka.kafka.{ConsumerActorTerminatedException, ConsumerSettings, KafkaConsumerActor, Subscription}
 import akka.stream.stage.GraphStageLogic.StageActor
 import akka.stream.stage.{GraphStageLogic, OutHandler}
 import akka.stream.{ActorMaterializerHelper, SourceShape}
@@ -51,7 +51,7 @@ private[kafka] abstract class SingleSourceLogic[K, V, Msg](
         }
         pump()
       case (_, Terminated(ref)) if ref == consumer =>
-        failStage(new Exception("Consumer actor terminated"))
+        failStage(new ConsumerActorTerminatedException)
     }
     self.watch(consumer)
 

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -6,7 +6,7 @@ package akka.kafka.internal
 
 import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
 import akka.kafka.Subscriptions._
-import akka.kafka.{ConsumerActorTerminatedException, ConsumerSettings, KafkaConsumerActor, Subscription}
+import akka.kafka.{ConsumerFailed, ConsumerSettings, KafkaConsumerActor, Subscription}
 import akka.stream.stage.GraphStageLogic.StageActor
 import akka.stream.stage.{GraphStageLogic, OutHandler}
 import akka.stream.{ActorMaterializerHelper, SourceShape}
@@ -51,7 +51,7 @@ private[kafka] abstract class SingleSourceLogic[K, V, Msg](
         }
         pump()
       case (_, Terminated(ref)) if ref == consumer =>
-        failStage(new ConsumerActorTerminatedException)
+        failStage(new ConsumerFailed)
     }
     self.watch(consumer)
 

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -8,7 +8,7 @@ import akka.NotUsed
 import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
 import akka.kafka.Subscriptions.{TopicSubscription, TopicSubscriptionPattern}
 import akka.kafka.scaladsl.Consumer.Control
-import akka.kafka.{AutoSubscription, ConsumerActorTerminatedException, ConsumerSettings, KafkaConsumerActor}
+import akka.kafka.{AutoSubscription, ConsumerFailed, ConsumerSettings, KafkaConsumerActor}
 import akka.stream.scaladsl.Source
 import akka.stream.stage.GraphStageLogic.StageActor
 import akka.stream.stage._
@@ -42,7 +42,7 @@ private[kafka] abstract class SubSourceLogic[K, V, Msg](
 
     self = getStageActor {
       case (_, Terminated(ref)) if ref == consumer =>
-        failStage(new ConsumerActorTerminatedException)
+        failStage(new ConsumerFailed)
     }
     self.watch(consumer)
 
@@ -165,7 +165,7 @@ private[kafka] abstract class SubSourceLogic[K, V, Msg](
               }
               pump()
             case (_, Terminated(ref)) if ref == consumer =>
-              failStage(new ConsumerActorTerminatedException)
+              failStage(new ConsumerFailed)
           }
           self.watch(consumer)
         }

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -8,7 +8,7 @@ import akka.NotUsed
 import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
 import akka.kafka.Subscriptions.{TopicSubscription, TopicSubscriptionPattern}
 import akka.kafka.scaladsl.Consumer.Control
-import akka.kafka.{AutoSubscription, ConsumerSettings, KafkaConsumerActor}
+import akka.kafka.{AutoSubscription, ConsumerActorTerminatedException, ConsumerSettings, KafkaConsumerActor}
 import akka.stream.scaladsl.Source
 import akka.stream.stage.GraphStageLogic.StageActor
 import akka.stream.stage._
@@ -42,7 +42,7 @@ private[kafka] abstract class SubSourceLogic[K, V, Msg](
 
     self = getStageActor {
       case (_, Terminated(ref)) if ref == consumer =>
-        failStage(new Exception("Consumer actor terminated"))
+        failStage(new ConsumerActorTerminatedException)
     }
     self.watch(consumer)
 
@@ -165,7 +165,7 @@ private[kafka] abstract class SubSourceLogic[K, V, Msg](
               }
               pump()
             case (_, Terminated(ref)) if ref == consumer =>
-              failStage(new Exception("Consumer actor terminated"))
+              failStage(new ConsumerActorTerminatedException)
           }
           self.watch(consumer)
         }


### PR DESCRIPTION
When the `KafkaConsumerActor` dies the stream stage would fail with `new Exception("Consumer actor terminated")`. This is more DRY and gives an exception type that can be matched on, rather than having to do something more awkward like 
```
case ex: Exception if ex.getMessage.contains("Consumer actor terminated") => ...
```