### PR TITLE
update to Akka 2.5.7, #368

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,3 @@ env:
   global:
     # encrypt with: travis encrypt WHITESOURCE_KEY=...
     - secure: "WrsJARX85hk+6YojUDLZpQEdHn9PkqIJuxSr5KIbDVUHUQo6H+P4QA5jNPTJjmEh3T+smvkP0doV+ouyZtEkPU0Yzc0f63/5COgROS2mSjDVVAUJlRDgcGfYTAzC5nB7UQEqoQmG2Z7MhkLt3fNSgOxQ3csHLFtkQEVGO+/EQHk="
-  matrix:
-    - AKKA_SERIES=2.4
-    - AKKA_SERIES=2.5

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you have questions or are working on a pull request or just curious, please f
 Created and maintained by
 [<img src="https://softwaremill.com/images/header-main-logo.3449d6a3.svg" alt="SoftwareMill logo" height="25">](https://softwaremill.com)
 
-## Documentation for version 0.11 or later
+## Documentation for version 0.18 or later
 
 [Documentation](http://doc.akka.io/docs/akka-stream-kafka/current/) and [API](http://doc.akka.io/api/akka-stream-kafka/current/)
 
@@ -23,15 +23,11 @@ Supports Kafka 0.9.0.x
 
 ## Akka versions compatibility
 
-Please note that while the library depends on Akka 2.4.x is fully compatible to be used with Akka 2.5.x.
-This is because of Akka's strict [backwards compatibility guarantees](http://doc.akka.io/docs/akka/2.5.3/scala/common/binary-compatibility-rules.html). If you want to use reactive-kafka with Akka 2.5 simply include Akka **and** Akka Streams dependencies using the latest 2.5 version, for example like this:
-
-```
-libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.5.x" // pick the latest version here
-libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.5.x"
-```
+Please note that the library depends on Akka 2.5.x. It can't be used with Akka 2.4.x. Version 0.17 and earlier can be used with Akka 2.4.x.
 
 Note that it is important that all `akka-*` dependencies are in the same version, so it is recommended to depend on them explicitly to avoid problems with transient dependencies causing an unlucky mix of versions.
+
+See also [Akka Compatibility Rules](http://doc.akka.io/docs/akka/current/scala/common/binary-compatibility-rules.html).
 
 ## Contributions
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,7 @@ import de.heikoseeberger.sbtheader.HeaderPattern
 
 name := "akka-stream-kafka"
 
-val akkaVersion = sys.env.get("AKKA_SERIES") match {
-  case Some("2.5") => "2.5.6"
-  case _ => "2.4.20"
-}
+val akkaVersion = "2.5.7"
 val kafkaVersion = "0.11.0.1"
 
 val kafkaClients = "org.apache.kafka" % "kafka-clients" % kafkaVersion

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -271,23 +271,23 @@ class ConsumerSettings[K, V](
     withProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId)
 
   /**
-    * The raw properties of the kafka-clients driver, see constants in
-    * `org.apache.kafka.clients.consumer.ConsumerConfig`.
-    */
+   * The raw properties of the kafka-clients driver, see constants in
+   * `org.apache.kafka.clients.consumer.ConsumerConfig`.
+   */
   def withProperties(properties: Map[String, String]): ConsumerSettings[K, V] =
     copy(properties = this.properties ++ properties)
 
   /**
-    * The raw properties of the kafka-clients driver, see constants in
-    * `org.apache.kafka.clients.consumer.ConsumerConfig`.
-    */
+   * The raw properties of the kafka-clients driver, see constants in
+   * `org.apache.kafka.clients.consumer.ConsumerConfig`.
+   */
   def withProperties(properties: (String, String)*): ConsumerSettings[K, V] =
     copy(properties = this.properties ++ properties.toMap)
 
   /**
-    * The raw properties of the kafka-clients driver, see constants in
-    * `org.apache.kafka.clients.consumer.ConsumerConfig`.
-    */
+   * The raw properties of the kafka-clients driver, see constants in
+   * `org.apache.kafka.clients.consumer.ConsumerConfig`.
+   */
   def withProperties(properties: java.util.Map[String, String]): ConsumerSettings[K, V] =
     copy(properties = this.properties ++ properties.asScala)
 

--- a/core/src/main/scala/akka/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ProducerSettings.scala
@@ -17,7 +17,6 @@ import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration._
 
-
 object ProducerSettings {
 
   /**
@@ -153,23 +152,23 @@ final class ProducerSettings[K, V](
     withProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
 
   /**
-    * The raw properties of the kafka-clients driver, see constants in
-    * `org.apache.kafka.clients.producer.ProducerConfig`.
-    */
+   * The raw properties of the kafka-clients driver, see constants in
+   * `org.apache.kafka.clients.producer.ProducerConfig`.
+   */
   def withProperties(properties: Map[String, String]): ProducerSettings[K, V] =
     copy(properties = this.properties ++ properties)
 
   /**
-    * The raw properties of the kafka-clients driver, see constants in
-    * `org.apache.kafka.clients.producer.ProducerConfig`.
-    */
+   * The raw properties of the kafka-clients driver, see constants in
+   * `org.apache.kafka.clients.producer.ProducerConfig`.
+   */
   def withProperties(properties: (String, String)*): ProducerSettings[K, V] =
     copy(properties = this.properties ++ properties.toMap)
 
   /**
-    * The raw properties of the kafka-clients driver, see constants in
-    * `org.apache.kafka.clients.producer.ProducerConfig`.
-    */
+   * The raw properties of the kafka-clients driver, see constants in
+   * `org.apache.kafka.clients.producer.ProducerConfig`.
+   */
   def withProperties(properties: java.util.Map[String, String]): ProducerSettings[K, V] =
     copy(properties = this.properties ++ properties.asScala)
 


### PR DESCRIPTION
* and remove CallbackWrapper, since that internal class was
  removed in 2.5.7
* the AsyncCallback is now safe to use immediately as materialized
  value

Refs #368