### PR TITLE
Replace calls to deprecated `expectNoMsg`-method

### DIFF
--- a/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
@@ -120,7 +120,7 @@ class ConsumerTest(_system: ActorSystem)
 
       probe
         .request(1)
-        .expectNoMsg()
+        .expectNoMessage(200.millis)
         .cancel()
     }
   }
@@ -134,7 +134,7 @@ class ConsumerTest(_system: ActorSystem)
 
     probe
       .request(1)
-      .expectNoMsg()
+      .expectNoMessage(200.millis)
       .cancel()
   }
 
@@ -559,7 +559,7 @@ class ConsumerTest(_system: ActorSystem)
       }
 
       probe.cancel()
-      probe.expectNoMsg(200.millis)
+      probe.expectNoMessage(200.millis)
       control.isShutdown.isCompleted should ===(false)
 
       //emulate commit

--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -220,7 +220,7 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
       // enqueue some more
       Await.result(produce(topic1, 101 to 110), remainingOrDefault)
 
-      probe1.expectNoMsg(200.millis)
+      probe1.expectNoMessage(200.millis)
 
       // then commit, which triggers a new poll while we haven't drained
       // previous buffer
@@ -329,7 +329,7 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
 
         probe
           .request(100)
-          .expectNoMsg(1.second)
+          .expectNoMessage(1.second)
 
         probe.cancel()
       }


### PR DESCRIPTION
Applying this PR will remove 5 warnings.