### PR TITLE
Remove final modifier from ProducerSettings class (#387)

### DIFF
--- a/core/src/main/scala/akka/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ProducerSettings.scala
@@ -139,7 +139,7 @@ object ProducerSettings {
  * `apply` and `create` functions for convenient construction of the settings, together with
  * the `with` methods.
  */
-final class ProducerSettings[K, V](
+class ProducerSettings[K, V](
     val properties: Map[String, String],
     val keySerializerOpt: Option[Serializer[K]],
     val valueSerializerOpt: Option[Serializer[V]],


### PR DESCRIPTION
Allow akka.kafka.ProducerSettings to be extended as it is very inconvenient when somebody wants to unit test the custom flow attached to a sink from akka.kafka.scaladsl.Producer.
Ideally to make a true unit test the real Kafka akka streams sink could be created using a mocked or fake ProducerSettings that when called createKafkaProducer would return a custom org.apache.kafka.clients.producer.Producer like org.apache.kafka.clients.producer.MockProducer or just some mock from mockito.