### PR TITLE
Expose offsetsForTimes function from kafkaConsumer with auto rebalance

### DIFF
--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -33,22 +33,22 @@ object Subscriptions {
   private[kafka] final case class AssignmentOffsetsForTimes(timestampsToSearch: Map[TopicPartition, Long]) extends ManualSubscription
 
   /**
-   * Creates subscription for given set of topics
+   * Creates subscription starting from `timestamp` for given set of topics
    */
-  def topicsWithTimestamp(timestamp: Long, ts: Set[String]): AutoSubscription = TopicSubscriptionWithStartTimestamp(timestamp, ts)
+  def topicsWithStartTimestamp(timestamp: Long, ts: Set[String]): AutoSubscription = TopicSubscriptionWithStartTimestamp(timestamp, ts)
 
   /**
-   * Creates subscription for given set of topics
+   * Creates subscription starting from `timestamp` for given set of topics
    * JAVA API
    */
   @varargs
-  def topics(timestamp: Long, ts: String*): AutoSubscription = topicsWithTimestamp(timestamp, ts.toSet)
+  def topics(timestamp: Long, ts: String*): AutoSubscription = topicsWithStartTimestamp(timestamp, ts.toSet)
 
   /**
-   * Creates subscription for given set of topics
+   * Creates subscription starting from `timestamp` for given set of topics
    * JAVA API
    */
-  def topics(timestamp: Long, ts: java.util.Set[String]): AutoSubscription = topicsWithTimestamp(timestamp, ts.asScala.toSet)
+  def topics(timestamp: Long, ts: java.util.Set[String]): AutoSubscription = topicsWithStartTimestamp(timestamp, ts.asScala.toSet)
 
   /**
    * Creates subscription for given set of topics

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -25,11 +25,30 @@ sealed trait ManualSubscription extends Subscription
 sealed trait AutoSubscription extends Subscription
 
 object Subscriptions {
+  private[kafka] final case class TopicSubscriptionWithStartTimestamp(timestamp: Long, tps: Set[String]) extends AutoSubscription
   private[kafka] final case class TopicSubscription(tps: Set[String]) extends AutoSubscription
   private[kafka] final case class TopicSubscriptionPattern(pattern: String) extends AutoSubscription
   private[kafka] final case class Assignment(tps: Set[TopicPartition]) extends ManualSubscription
   private[kafka] final case class AssignmentWithOffset(tps: Map[TopicPartition, Long]) extends ManualSubscription
   private[kafka] final case class AssignmentOffsetsForTimes(timestampsToSearch: Map[TopicPartition, Long]) extends ManualSubscription
+
+  /**
+   * Creates subscription for given set of topics
+   */
+  def topicsWithTimestamp(timestamp: Long, ts: Set[String]): AutoSubscription = TopicSubscriptionWithStartTimestamp(timestamp, ts)
+
+  /**
+   * Creates subscription for given set of topics
+   * JAVA API
+   */
+  @varargs
+  def topics(timestamp: Long, ts: String*): AutoSubscription = topicsWithTimestamp(timestamp, ts.toSet)
+
+  /**
+   * Creates subscription for given set of topics
+   * JAVA API
+   */
+  def topics(timestamp: Long, ts: java.util.Set[String]): AutoSubscription = topicsWithTimestamp(timestamp, ts.asScala.toSet)
 
   /**
    * Creates subscription for given set of topics

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -78,6 +78,8 @@ private[kafka] abstract class SingleSourceLogic[K, V, Msg](
       KafkaConsumerActor.rebalanceListener(tps => partitionAssignedCB.invoke(tps), partitionRevokedCB.invoke)
 
     subscription match {
+      case TopicSubscriptionWithStartTimestamp(timestamp, topics) =>
+        consumer.tell(KafkaConsumerActor.Internal.SubscribeWithStartTimestamp(timestamp, topics, rebalanceListener), self.ref)
       case TopicSubscription(topics) =>
         consumer.tell(KafkaConsumerActor.Internal.Subscribe(topics, rebalanceListener), self.ref)
       case TopicSubscriptionPattern(topics) =>

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit
 
 import akka.NotUsed
 import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
-import akka.kafka.Subscriptions.{TopicSubscription, TopicSubscriptionPattern}
+import akka.kafka.Subscriptions.{TopicSubscription, TopicSubscriptionPattern, TopicSubscriptionWithStartTimestamp}
 import akka.kafka.scaladsl.Consumer.Control
 import akka.kafka.{AutoSubscription, ConsumerFailed, ConsumerSettings, KafkaConsumerActor}
 import akka.pattern.{AskTimeoutException, ask}
@@ -59,6 +59,8 @@ private[kafka] abstract class SubSourceLogic[K, V, Msg](
       KafkaConsumerActor.rebalanceListener(partitionAssignedCB, partitionRevokedCB)
 
     subscription match {
+      case TopicSubscriptionWithStartTimestamp(timestamp, topics) =>
+        consumer.tell(KafkaConsumerActor.Internal.SubscribeWithStartTimestamp(timestamp, topics, rebalanceListener), self.ref)
       case TopicSubscription(topics) =>
         consumer.tell(KafkaConsumerActor.Internal.Subscribe(topics, rebalanceListener), self.ref)
       case TopicSubscriptionPattern(topics) =>


### PR DESCRIPTION
The PR is the continuation of https://github.com/akka/reactive-kafka/pull/340 . It adds an integration test, some logging, and some minor code restructuring. In order to be self-contained I'll repeat the original PR description:

> You can use this to get topic/partitions offsets from a timestamp (i.e Kafka timestamp https://cwiki.apache.org/confluence/display/KAFKA/KIP-32+-+Add+timestamps+to+Kafka+message) to setup the initial position in kafka when starting the stream.
> 
> This will work with auto-rebalance if you don't want to manually manage your kafka offset commit.
> 
> Discussion on #267 

@raboof @nsphung 