### PR TITLE
Docs for consumer shutdown

### DIFF
--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -216,3 +216,5 @@ When you are batching the commit messages for better throughput as described ear
 
 The `Consumer.Control` methods return `Future[Done]`, so they should be chained in a for-comprehension.
 
+Scala
+: @@ snip [streamShutdownBatched](../../test/scala/sample/scaladsl/ConsumerExample.scala) { #streamShutdownBatched }

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -205,8 +205,12 @@ The streams created with `Consumer.plainSource` and similar  methods materialize
 
 If you are not batching commits, a call to `Consumer.Control.shutdown()` suffices. This stops producing messages from the source and waits for all messages to have been committed.
 
+
 Scala
 : @@ snip [streamShutdown](../../test/scala/sample/scaladsl/ConsumerExample.scala) { #streamShutdown }
+
+Java
+: @@ snip [streamShutdown](../../test/java/sample/javadsl/ConsumerExample.java) { #streamShutdown }
 
 When you are batching the commit messages for better throughput as described earlier, besides the `Consumer.Control`, it is recommended to add a [`KillSwitch`](https://doc.akka.io/docs/akka/2.5/stream/stream-dynamic.html#controlling-graph-completion-with-killswitch) to the stream and stop it in several steps:
 
@@ -218,3 +222,6 @@ The `Consumer.Control` methods return `Future[Done]`, so they should be chained 
 
 Scala
 : @@ snip [streamShutdownBatched](../../test/scala/sample/scaladsl/ConsumerExample.scala) { #streamShutdownBatched }
+
+Java
+: @@ snip [streamShutdownBatched](../../test/java/sample/javadsl/ConsumerExample.java) { #streamShutdownBatched }

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -212,13 +212,11 @@ Scala
 Java
 : @@ snip [streamShutdown](../../test/java/sample/javadsl/ConsumerExample.java) { #streamShutdown }
 
-When you are batching the commit messages for better throughput as described earlier, besides the `Consumer.Control`, it is recommended to add a [`KillSwitch`](https://doc.akka.io/docs/akka/2.5/stream/stream-dynamic.html#controlling-graph-completion-with-killswitch) to the stream and stop it in several steps:
+When you are batching the commit messages for better throughput as described earlier, shutdown involves several steps:
 
 1. `Consumer.Control.stop()` to stop producing messages from the source. This does not complete the source and does not stop the underlying consumer.
-2. `KillSwitch.shutdown()` to flush any batched commits.
-3. `Consumer.Control.shutdown()` to wait until all messages produced from the source have been committed. 
-
-The `Consumer.Control` methods return `Future[Done]`, so they should be chained in a for-comprehension.
+2. Wait for the stream to complete, so that any batched offset commits are flushed and have resulted in commit requests to the Kafka broker.
+3. `Consumer.Control.shutdown()` to wait for all outstanding commit requests to finish.
 
 Scala
 : @@ snip [streamShutdownBatched](../../test/scala/sample/scaladsl/ConsumerExample.scala) { #streamShutdownBatched }

--- a/docs/src/test/java/sample/javadsl/ConsumerExample.java
+++ b/docs/src/test/java/sample/javadsl/ConsumerExample.java
@@ -433,10 +433,10 @@ class ShutdownCommittableSourceExample extends ConsumerExample {
             .run(materializer);
 
     Consumer.Control control = r.first();
-    CompletionStage<Done> done = r.second();
+    CompletionStage<Done> streamComplete = r.second();
 
     control.stop()
-        .thenCompose(result -> done)
+        .thenCompose(result -> streamComplete)
         .thenCompose(result -> control.shutdown());
     // #shutdownCommitableSource
   }

--- a/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
+++ b/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
@@ -482,7 +482,7 @@ object ShutdownPlainSourceExample extends ConsumerExample {
       val subscription = Subscriptions.assignmentWithOffset(
         new TopicPartition("topic1", partition) -> fromOffset
       )
-      val (consumerControl, done) =
+      val (consumerControl, streamComplete) =
         Consumer.plainSource(consumerSettings, subscription)
           .mapAsync(1)(db.save)
           .toMat(Sink.ignore)(Keep.both)
@@ -491,7 +491,7 @@ object ShutdownPlainSourceExample extends ConsumerExample {
       consumerControl.shutdown()
       // #shutdownPlainSource
 
-      terminateWhenDone(done)
+      terminateWhenDone(streamComplete)
     }
   }
 }
@@ -502,7 +502,7 @@ object ShutdownCommitableSourceExample extends ConsumerExample {
     // #shutdownCommitableSource
     val db = new DB
 
-    val (consumerControl, done) =
+    val (consumerControl, streamComplete) =
       Consumer.committableSource(consumerSettings, Subscriptions.topics("topic1"))
         .mapAsync(1) { msg =>
           db.update(msg.record.value).map(_ => msg.committableOffset)
@@ -516,12 +516,12 @@ object ShutdownCommitableSourceExample extends ConsumerExample {
 
     for {
       _ <- consumerControl.stop()
-      _ <- done
+      _ <- streamComplete
       _ <- consumerControl.shutdown()
     } yield Done
 
     // #shutdownCommitableSource
 
-    terminateWhenDone(done)
+    terminateWhenDone(streamComplete)
   }
 }

--- a/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
+++ b/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
@@ -10,7 +10,7 @@ import akka.kafka._
 import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, PoisonPill, Props}
 import akka.kafka.scaladsl.{Consumer, Producer}
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
-import akka.stream.{ActorMaterializer, KillSwitches, ThrottleMode}
+import akka.stream.{ActorMaterializer}
 import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord}
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -21,8 +21,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 import java.util.concurrent.atomic.AtomicLong
-
-import akka.util.Timeout
 
 trait ConsumerExample {
   val system = ActorSystem("example")


### PR DESCRIPTION
See #432 

This is an addition to the Consumer docs on how to shutdown a consumer stream. This is especially interesting when using batched commits. Code examples are included.

My scala is better than my java, so I'm more than happy to accept improvements/corrections there of course.