### PR TITLE
fix: add-wait-in-rebalancing-to-close-partition

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -21,11 +21,12 @@ import akka.stream.stage._
 import akka.stream.{ActorMaterializerHelper, Attributes, Outlet, SourceShape}
 import akka.util.Timeout
 import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
+import org.apache.kafka.common.TopicPartition
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success}
 
 private[kafka] abstract class SubSourceLogic[K, V, Msg](
@@ -223,7 +224,12 @@ private[kafka] abstract class SubSourceLogic[K, V, Msg](
         })
 
         def performShutdown() = {
-          completeStage()
+          materializer.scheduleOnce(
+            FiniteDuration(5, "seconds"),
+            new Runnable {
+              override def run(): Unit = completeStage()
+            }
+          )
         }
 
         @tailrec

--- a/core/src/test/scala/akka/kafka/internal/MyTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/MyTest.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.kafka.internal
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import akka.actor.ActorSystem
+import akka.kafka.scaladsl.Consumer
+import akka.kafka.{ConsumerSettings, Subscriptions}
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, SinkQueueWithCancel}
+import akka.testkit.TestKit
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest._
+
+// Very dirty way of reproducing https://github.com/akka/reactive-kafka/issues/382
+class MyTest extends TestKit(ActorSystem("IntegrationSpec"))
+  with FlatSpecLike with MustMatchers with BeforeAndAfterAll
+  with BeforeAndAfterEach with TypeCheckedTripleEquals {
+
+  implicit val mat = ActorMaterializer()(system)
+  implicit val ec = system.dispatcher
+  implicit val embeddedKafkaConfig = EmbeddedKafkaConfig(9099, 2189, Map("offsets.topic.replication.factor" -> "1"))
+  val bootstrapServers = s"localhost:${embeddedKafkaConfig.kafkaPort}"
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    EmbeddedKafka.start()
+    EmbeddedKafka.createCustomTopic("test1", partitions = 10)
+    EmbeddedKafka.createCustomTopic("test2", partitions = 10)
+  }
+
+  override def afterAll(): Unit = {
+    shutdown(system, 30.seconds)
+    EmbeddedKafka.stop()
+    super.afterAll()
+  }
+
+  private def extractAll(trie: scala.collection.concurrent.TrieMap[String, Unit], queue: SinkQueueWithCancel[String]): Future[Unit] = {
+    queue.pull().flatMap { opt =>
+      if (opt.isDefined) {
+        trie.put(opt.get, ())
+        extractAll(trie, queue)
+      }
+      else Future.successful(())
+    }
+  }
+
+  ignore must "test that works" in {
+    def getSinkQueue() = {
+      Consumer.plainPartitionedSource(
+        ConsumerSettings(system, new StringDeserializer, new StringDeserializer)
+          .withBootstrapServers(bootstrapServers)
+          .withGroupId("mygroup")
+          .withProperty("auto.offset.reset", "earliest"),
+        Subscriptions.topics("test1")
+      ).flatMapMerge(10, _._2)
+        .map(_.value())
+        .runWith(Sink.queue())
+    }
+    val trie = new scala.collection.concurrent.TrieMap[String, Unit]()
+    val queue1 = getSinkQueue()
+    val queue2 = getSinkQueue()
+    extractAll(trie, queue1)
+    extractAll(trie, queue2)
+    Thread.sleep(10000)
+
+    (1 to 2000).par.foreach { i =>
+      EmbeddedKafka.publishStringMessageToKafka("test1", i.toString)
+    }
+    Thread.sleep(10000)
+    println(s"Set size: ${trie.size}")
+    println("Missing: " + ((1 to 2000).toSet -- trie.keys.map(_.toInt)))
+    trie.size must be (2000)
+    queue1.cancel()
+    queue2.cancel()
+  }
+
+  it must "test that doesn't work" in {
+    def getSinkQueue() = {
+      Consumer.plainPartitionedSource(
+        ConsumerSettings(system, new StringDeserializer, new StringDeserializer)
+          .withBootstrapServers(bootstrapServers)
+          .withGroupId("mygroup2")
+          .withProperty("auto.offset.reset", "earliest"),
+        Subscriptions.topics("test2")
+      ).flatMapMerge(10, _._2)
+        .map(_.value())
+        .runWith(Sink.queue())
+    }
+    val trie = new scala.collection.concurrent.TrieMap[String, Unit]()
+    val queue1 = getSinkQueue()
+    extractAll(trie, queue1)
+
+    (1 to 1000).foreach { i =>
+      EmbeddedKafka.publishStringMessageToKafka("test2", i.toString)
+    }
+    val queue2 = getSinkQueue()
+    extractAll(trie, queue2)
+    (1001 to 2000).foreach { i =>
+      EmbeddedKafka.publishStringMessageToKafka("test2", i.toString)
+    }
+    Thread.sleep(10000)
+    println(s"Set size: ${trie.size}")
+    println("Missing: " + ((1 to 2000).toSet -- trie.keys.map(_.toInt)))
+    trie.size must be (2000)
+    Thread.sleep(2000)
+    queue1.cancel()
+    queue2.cancel()
+    Thread.sleep(2000)
+  }
+}


### PR DESCRIPTION
Add async wait when close a partition in order to wait to pending requests