### PR TITLE
Upgrade to Akka 2.5.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalariform.formatter.preferences._
 
 name := "akka-stream-kafka"
 
-val akkaVersion = "2.5.9"
+val akkaVersion = "2.5.12"
 val kafkaVersion = "1.0.1"
 
 val kafkaClients = "org.apache.kafka" % "kafka-clients" % kafkaVersion

--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -178,6 +178,7 @@ object Consumer {
    */
   def plainExternalSource[K, V](consumer: ActorRef, subscription: ManualSubscription): Source[ConsumerRecord[K, V], Control] = {
     scaladsl.Consumer.plainExternalSource(consumer, subscription)
+      .map{ identity[org.apache.kafka.clients.consumer.ConsumerRecord[K, V]] }
       .mapMaterializedValue(new WrappedConsumerControl(_))
       .asJava
   }
@@ -187,6 +188,7 @@ object Consumer {
    */
   def committableExternalSource[K, V](consumer: ActorRef, subscription: ManualSubscription, groupId: String, commitTimeout: FiniteDuration): Source[CommittableMessage[K, V], Control] = {
     scaladsl.Consumer.committableExternalSource(consumer, subscription, groupId, commitTimeout)
+      .map{ identity[CommittableMessage[K, V]] }
       .mapMaterializedValue(new WrappedConsumerControl(_))
       .asJava
   }

--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -178,9 +178,9 @@ object Consumer {
    */
   def plainExternalSource[K, V](consumer: ActorRef, subscription: ManualSubscription): Source[ConsumerRecord[K, V], Control] = {
     scaladsl.Consumer.plainExternalSource(consumer, subscription)
-      .map{ identity[org.apache.kafka.clients.consumer.ConsumerRecord[K, V]] }
       .mapMaterializedValue(new WrappedConsumerControl(_))
       .asJava
+      .asInstanceOf[Source[ConsumerRecord[K, V], Control]]
   }
 
   /**
@@ -188,8 +188,8 @@ object Consumer {
    */
   def committableExternalSource[K, V](consumer: ActorRef, subscription: ManualSubscription, groupId: String, commitTimeout: FiniteDuration): Source[CommittableMessage[K, V], Control] = {
     scaladsl.Consumer.committableExternalSource(consumer, subscription, groupId, commitTimeout)
-      .map{ identity[CommittableMessage[K, V]] }
       .mapMaterializedValue(new WrappedConsumerControl(_))
       .asJava
+      .asInstanceOf[Source[CommittableMessage[K, V], Control]]
   }
 }

--- a/core/src/main/scala/akka/kafka/javadsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Producer.scala
@@ -79,7 +79,9 @@ object Producer {
    * be committed later in the flow.
    */
   def flow[K, V, PassThrough](settings: ProducerSettings[K, V]): Flow[Message[K, V, PassThrough], Result[K, V, PassThrough], NotUsed] =
-    scaladsl.Producer.flow(settings).asJava
+    scaladsl.Producer.flow(settings)
+      .map { identity[Result[K, V, PassThrough]] }
+      .asJava
 
   /**
    * Publish records to Kafka topics and then continue the flow. Possibility to pass through a message, which
@@ -90,5 +92,7 @@ object Producer {
     settings: ProducerSettings[K, V],
     producer: KProducer[K, V]
   ): Flow[Message[K, V, PassThrough], Result[K, V, PassThrough], NotUsed] =
-    scaladsl.Producer.flow(settings, producer).asJava
+    scaladsl.Producer.flow(settings, producer)
+      .map { identity[Result[K, V, PassThrough]] }
+      .asJava
 }

--- a/core/src/main/scala/akka/kafka/javadsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Producer.scala
@@ -80,8 +80,8 @@ object Producer {
    */
   def flow[K, V, PassThrough](settings: ProducerSettings[K, V]): Flow[Message[K, V, PassThrough], Result[K, V, PassThrough], NotUsed] =
     scaladsl.Producer.flow(settings)
-      .map { identity[Result[K, V, PassThrough]] }
       .asJava
+      .asInstanceOf[Flow[Message[K, V, PassThrough], Result[K, V, PassThrough], NotUsed]]
 
   /**
    * Publish records to Kafka topics and then continue the flow. Possibility to pass through a message, which
@@ -93,6 +93,6 @@ object Producer {
     producer: KProducer[K, V]
   ): Flow[Message[K, V, PassThrough], Result[K, V, PassThrough], NotUsed] =
     scaladsl.Producer.flow(settings, producer)
-      .map { identity[Result[K, V, PassThrough]] }
       .asJava
+      .asInstanceOf[Flow[Message[K, V, PassThrough], Result[K, V, PassThrough], NotUsed]]
 }


### PR DESCRIPTION
The conversion to Java APIs requires a few extra type hints.
https://github.com/akka/akka/issues/24368