### PR TITLE
Always increments the ProducerStage counter before decrement and check

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
@@ -70,6 +70,7 @@ private[kafka] class ProducerStage[K, V, P](
         override def onPush() = {
           val msg = grab(in)
           val r = Promise[Result[K, V, P]]
+          awaitingConfirmation.incrementAndGet()
           producer.send(msg.record, new Callback {
             override def onCompletion(metadata: RecordMetadata, exception: Exception) = {
               if (exception == null) {
@@ -91,7 +92,6 @@ private[kafka] class ProducerStage[K, V, P](
                 checkForCompletionCB.invoke(())
             }
           })
-          awaitingConfirmation.incrementAndGet()
           push(out, r.future)
         }
 


### PR DESCRIPTION
There was a possibility that it would be decremented and checked before the corresponding increment, leading to a failure to check for completion.