### PR TITLE
Restructure integration test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -115,6 +115,8 @@ lazy val core = project
   .settings(commonSettings)
   .settings(Seq(
     name := "akka-stream-kafka",
+    Test/fork := true,
+    Test/parallelExecution := false,
     libraryDependencies ++= commonDependencies ++ coreDependencies
 ))
 

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -15,10 +15,9 @@ import akka.stream.stage.GraphStageLogic.StageActor
 import akka.stream.stage.{GraphStageLogic, OutHandler, StageLogging}
 import akka.stream.{ActorMaterializerHelper, SourceShape}
 import akka.util.Timeout
-import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord}
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
-import scala.collection.JavaConverters._
 import scala.annotation.tailrec
 import scala.concurrent.Future
 

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -9,8 +9,6 @@ import java.util.concurrent.TimeUnit
 
 import akka.NotUsed
 import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
-import akka.dispatch.ExecutionContexts
-import akka.kafka.KafkaConsumerActor.Internal.{ConsumerMetrics, RequestMetrics}
 import akka.kafka.Subscriptions.{TopicSubscription, TopicSubscriptionPattern}
 import akka.kafka.scaladsl.Consumer.Control
 import akka.kafka.{AutoSubscription, ConsumerFailed, ConsumerSettings, KafkaConsumerActor}
@@ -21,7 +19,7 @@ import akka.stream.stage._
 import akka.stream.{ActorMaterializerHelper, Attributes, Outlet, SourceShape}
 import akka.util.Timeout
 import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
+import org.apache.kafka.common.TopicPartition
 
 import scala.annotation.tailrec
 import scala.collection.immutable

--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -21,7 +21,6 @@ import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
 import scala.compat.java8.FutureConverters
-import scala.concurrent.Future
 
 /**
  * Akka Stream connector for subscribing to Kafka topics.

--- a/core/src/test/scala/akka/kafka/KafkaPorts.scala
+++ b/core/src/test/scala/akka/kafka/KafkaPorts.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.scaladsl
+
+/**
+ * Ports to use for Kafka and Zookeeper throughout integration tests.
+ * Zookeeper is Kafka port + 1 if nothing else specified.
+ */
+object KafkaPorts {
+
+  val IntegrationSpec = 9002
+  val RetentionPeriodSpec = 9012
+  val TransactionsSpec = 9022
+
+}

--- a/core/src/test/scala/akka/kafka/KafkaPorts.scala
+++ b/core/src/test/scala/akka/kafka/KafkaPorts.scala
@@ -3,7 +3,7 @@
  * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.kafka.scaladsl
+package akka.kafka
 
 /**
  * Ports to use for Kafka and Zookeeper throughout integration tests.

--- a/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
@@ -12,7 +12,6 @@ import akka.Done
 import akka.actor.ActorSystem
 import akka.kafka.ConsumerMessage._
 import akka.kafka.{CommitTimeoutException, ConsumerSettings, Subscriptions}
-import akka.kafka.Subscriptions.TopicSubscription
 import akka.kafka.scaladsl.Consumer
 import Consumer.Control
 import akka.stream._

--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class IntegrationSpec extends SpecBase(kafkaPort = 9092) {
+class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) {
 
   def createKafkaConfig: EmbeddedKafkaConfig =
     EmbeddedKafkaConfig(

--- a/core/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.scaladsl
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import akka.Done
+import akka.kafka._
+import akka.kafka.test.Utils._
+import akka.stream.scaladsl.Keep
+import akka.stream.testkit.scaladsl.TestSink
+import net.manub.embeddedkafka.EmbeddedKafkaConfig
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class RetentionPeriodSpec extends SpecBase(kafkaPort = 9012) {
+
+  def createKafkaConfig: EmbeddedKafkaConfig =
+    EmbeddedKafkaConfig(
+      kafkaPort, zooKeeperPort,
+      Map(
+        "offsets.topic.replication.factor" -> "1",
+        "offsets.retention.minutes" -> "1",
+        "offsets.retention.check.interval.ms" -> "100"
+      ))
+
+  "After retention period (1 min) consumer" must {
+
+    "resume from committed offset" in assertAllStagesStopped {
+      val topic1 = createTopic(1)
+      val group1 = createGroup(1)
+
+      givenInitializedTopic(topic1)
+      produce(topic1, 1 to 100)
+
+      val committedElements = new ConcurrentLinkedQueue[Int]()
+
+      val consumerSettings = consumerDefaults.withGroupId(group1).withCommitRefreshInterval(5.seconds)
+
+      val (control, probe1) = Consumer.committableSource(consumerSettings, Subscriptions.topics(topic1))
+        .filterNot(_.record.value == InitialMsg)
+        .mapAsync(10) { elem =>
+          elem.committableOffset.commitScaladsl().map { _ =>
+            committedElements.add(elem.record.value.toInt)
+            Done
+          }
+        }
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      probe1
+        .request(25)
+        .expectNextN(25).toSet should be(Set(Done))
+
+      val longerThanRetentionPeriod = 70000
+      Thread.sleep(longerThanRetentionPeriod)
+
+      probe1.cancel()
+      Await.result(control.isShutdown, remainingOrDefault)
+
+      val probe2 = Consumer.committableSource(consumerSettings, Subscriptions.topics(topic1))
+        .map(_.record.value)
+        .runWith(TestSink.probe)
+
+      // Note that due to buffers and mapAsync(10) the committed offset is more
+      // than 26, and that is not wrong
+
+      // some concurrent publish
+      produce(topic1, 101 to 200)
+
+      val expectedElements = ((committedElements.asScala.max + 1) to 100).map(_.toString)
+      probe2
+        .request(100)
+        .expectNextN(expectedElements)
+
+      Thread.sleep(longerThanRetentionPeriod)
+
+      probe2.cancel()
+
+      val probe3 = Consumer.committableSource(consumerSettings, Subscriptions.topics(topic1))
+        .map(_.record.value)
+        .runWith(TestSink.probe)
+
+      probe3
+        .request(100)
+        .expectNextN(expectedElements)
+
+      probe3.cancel()
+    }
+  }
+}

--- a/core/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
@@ -18,7 +18,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class RetentionPeriodSpec extends SpecBase(kafkaPort = 9012) {
+class RetentionPeriodSpec extends SpecBase(kafkaPort = KafkaPorts.RetentionPeriodSpec) {
 
   def createKafkaConfig: EmbeddedKafkaConfig =
     EmbeddedKafkaConfig(

--- a/core/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
@@ -17,7 +17,6 @@ import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 class RetentionPeriodSpec extends SpecBase(kafkaPort = 9012) {
 
@@ -58,7 +57,7 @@ class RetentionPeriodSpec extends SpecBase(kafkaPort = 9012) {
         .request(25)
         .expectNextN(25).toSet should be(Set(Done))
 
-      val longerThanRetentionPeriod = 70000
+      val longerThanRetentionPeriod = 70000L
       Thread.sleep(longerThanRetentionPeriod)
 
       probe1.cancel()

--- a/core/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.scaladsl
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.kafka._
+import akka.kafka.test.Utils._
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.TestSubscriber
+import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.testkit.TestKit
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
+import org.scalatest._
+import org.scalatest.concurrent.Eventually
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
+
+abstract class SpecBase(val kafkaPort: Int, val zooKeeperPort: Int, actorSystem: ActorSystem)
+  extends TestKit(actorSystem)
+  with WordSpecLike
+  with Matchers
+  with BeforeAndAfterAll
+  with Eventually {
+
+  def this(kafkaPort: Int) = this(kafkaPort, kafkaPort + 1, ActorSystem("Spec"))
+
+  implicit val stageStoppingTimeout: StageStoppingTimeout = StageStoppingTimeout(15.seconds)
+  implicit val mat: Materializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
+
+  implicit val embeddedKafkaConfig: EmbeddedKafkaConfig = createKafkaConfig
+
+  def createKafkaConfig: EmbeddedKafkaConfig
+
+  val bootstrapServers = s"localhost:${embeddedKafkaConfig.kafkaPort}"
+
+  var testProducer: KafkaProducer[String, String] = _
+
+  val DefaultKey = "key"
+  val InitialMsg =
+    "initial msg in topic, required to create the topic before any consumer subscribes to it"
+
+  val producerDefaults =
+    ProducerSettings(system, new StringSerializer, new StringSerializer)
+      .withBootstrapServers(bootstrapServers)
+
+  val consumerDefaults = ConsumerSettings(system, new StringDeserializer, new StringDeserializer)
+    .withBootstrapServers(bootstrapServers)
+    .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+    .withWakeupTimeout(10 seconds)
+    .withMaxWakeups(10)
+
+  override protected def beforeAll(): Unit = {
+    EmbeddedKafka.start()(embeddedKafkaConfig)
+    testProducer = producerDefaults.createKafkaProducer()
+  }
+
+  override def afterAll(): Unit = {
+    testProducer.close(60, TimeUnit.SECONDS)
+    TestKit.shutdownActorSystem(system)
+    EmbeddedKafka.stop()
+  }
+
+  private val topicCounter = new AtomicInteger()
+
+  def createTopic(number: Int) = s"topic-$number-${topicCounter.incrementAndGet()}"
+
+  def createGroup(number: Int) = s"group-$number-${topicCounter.incrementAndGet()}"
+
+  val partition0 = 0
+
+  def givenInitializedTopic(topic: String): Unit =
+    testProducer.send(new ProducerRecord(topic, partition0, DefaultKey, InitialMsg))
+
+  /**
+   * Produce messages to topic using specified range and return
+   * a Future so the caller can synchronize consumption.
+   */
+  def produce(topic: String, range: Range): Future[Done] =
+    Source(range)
+      // NOTE: If no partition is specified but a key is present a partition will be chosen
+      // using a hash of the key. If neither key nor partition is present a partition
+      // will be assigned in a round-robin fashion.
+      .map(n => new ProducerRecord(topic, partition0, DefaultKey, n.toString))
+      .runWith(Producer.plainSink(producerDefaults, testProducer))
+
+  /**
+   * Produce messages to topic using specified range and return
+   * a Future so the caller can synchronize consumption.
+   */
+  def produce(topic: String, range: Range, settings: ProducerSettings[String, String]): Future[Done] =
+    Source(range)
+      .map(n => new ProducerRecord(topic, partition0, DefaultKey, n.toString))
+      .runWith(Producer.plainSink(settings))
+
+  def createProbe(consumerSettings: ConsumerSettings[String, String], topic: String): TestSubscriber.Probe[String] =
+    Consumer
+      .plainSource(consumerSettings, Subscriptions.topics(topic))
+      .filterNot(_.value == InitialMsg)
+      .map(_.value)
+      .runWith(TestSink.probe)
+
+}

--- a/core/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -5,9 +5,6 @@
 
 package akka.kafka.scaladsl
 
-import java.util.concurrent.ConcurrentLinkedQueue
-
-import akka.Done
 import akka.kafka.Subscriptions.TopicSubscription
 import akka.kafka._
 import akka.kafka.scaladsl.Consumer.Control
@@ -18,10 +15,8 @@ import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 
-import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 class TransactionsSpec extends SpecBase(kafkaPort = 9022) {
 

--- a/core/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.scaladsl
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import akka.Done
+import akka.kafka.Subscriptions.TopicSubscription
+import akka.kafka._
+import akka.kafka.scaladsl.Consumer.Control
+import akka.kafka.test.Utils._
+import akka.stream.scaladsl.{Keep, RestartSource, Sink}
+import akka.stream.testkit.scaladsl.TestSink
+import net.manub.embeddedkafka.EmbeddedKafkaConfig
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerRecord
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class TransactionsSpec extends SpecBase(kafkaPort = 9022) {
+
+  def createKafkaConfig: EmbeddedKafkaConfig =
+    EmbeddedKafkaConfig(
+      kafkaPort, zooKeeperPort,
+      Map(
+        "offsets.topic.replication.factor" -> "1"
+      ))
+
+  "Transactions" must {
+
+    "complete a consume-transform-produce cycle" in {
+      assertAllStagesStopped {
+        val sourceTopic = createTopic(1)
+        val sinkTopic = createTopic(2)
+        val group = createGroup(1)
+
+        givenInitializedTopic(sourceTopic)
+        givenInitializedTopic(sinkTopic)
+
+        Await.result(produce(sourceTopic, 1 to 100), remainingOrDefault)
+
+        val consumerSettings = consumerDefaults.withGroupId(group)
+
+        val control = Consumer.transactionalSource(consumerSettings, TopicSubscription(Set(sourceTopic), None))
+          .filterNot(_.record.value() == InitialMsg)
+          .map { msg =>
+            ProducerMessage.Message(
+              new ProducerRecord[String, String](sinkTopic, msg.record.value), msg.partitionOffset)
+          }
+          .via(Producer.transactionalFlow(producerDefaults, group))
+          .toMat(Sink.ignore)(Keep.left)
+          .run()
+
+        val probeConsumerGroup = createGroup(2)
+        val probeConsumerSettings = consumerDefaults.withGroupId(probeConsumerGroup)
+          .withProperties(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
+
+        val probeConsumer = Consumer.plainSource(probeConsumerSettings, TopicSubscription(Set(sinkTopic), None))
+          .filterNot(_.value == InitialMsg)
+          .map(_.value())
+          .runWith(TestSink.probe)
+
+        probeConsumer
+          .request(100)
+          .expectNextN((1 to 100).map(_.toString))
+
+        probeConsumer.cancel()
+        Await.result(control.shutdown(), remainingOrDefault)
+      }
+    }
+
+    "complete a consume-transform-produce transaction with transient failure causing an abort with restartable source" in {
+      assertAllStagesStopped {
+        val sourceTopic = createTopic(1)
+        val sinkTopic = createTopic(2)
+        val group = createGroup(1)
+
+        givenInitializedTopic(sourceTopic)
+        givenInitializedTopic(sinkTopic)
+
+        Await.result(produce(sourceTopic, 1 to 1000), remainingOrDefault)
+
+        val consumerSettings = consumerDefaults.withGroupId(group)
+
+        var restartCount = 0
+        var innerControl = null.asInstanceOf[Control]
+
+        val restartSource = RestartSource.onFailuresWithBackoff(
+          minBackoff = 0.1.seconds,
+          maxBackoff = 1.seconds,
+          randomFactor = 0.2
+        ) { () =>
+          restartCount += 1
+          Consumer.transactionalSource(consumerSettings, TopicSubscription(Set(sourceTopic), None))
+            .filterNot(_.record.value() == InitialMsg)
+            .map { msg =>
+              if (msg.record.value().toInt == 500 && restartCount < 2) {
+                // add a delay that equals or exceeds EoS commit interval to trigger a commit for everything
+                // up until this record (0 -> 500)
+                Thread.sleep(producerDefaults.eosCommitInterval.toMillis + 10)
+              }
+              if (msg.record.value().toInt == 501 && restartCount < 2) {
+                throw new RuntimeException("Uh oh..")
+              }
+              else {
+                ProducerMessage.Message(
+                  new ProducerRecord[String, String](sinkTopic, msg.record.value()), msg.partitionOffset)
+              }
+            }
+            // side effect out the `Control` materialized value because it can't be propagated through the `RestartSource`
+            .mapMaterializedValue(innerControl = _)
+            .via(Producer.transactionalFlow(producerDefaults, group))
+        }
+
+        restartSource.runWith(Sink.ignore)
+
+        val probeGroup = createGroup(2)
+        val probeConsumerSettings = consumerDefaults.withGroupId(probeGroup)
+          .withProperties(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
+
+        val probeConsumer = Consumer.plainSource(probeConsumerSettings, TopicSubscription(Set(sinkTopic), None))
+          .filterNot(_.value == InitialMsg)
+          .map(_.value())
+          .runWith(TestSink.probe)
+
+        probeConsumer
+          .request(1000)
+          .expectNextN((1 to 1000).map(_.toString))
+
+        probeConsumer.cancel()
+        Await.result(innerControl.shutdown(), remainingOrDefault)
+      }
+    }
+
+  }
+}

--- a/core/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -18,7 +18,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class TransactionsSpec extends SpecBase(kafkaPort = 9022) {
+class TransactionsSpec extends SpecBase(kafkaPort = KafkaPorts.TransactionsSpec) {
 
   def createKafkaConfig: EmbeddedKafkaConfig =
     EmbeddedKafkaConfig(

--- a/docs/src/test/java/sample/javadsl/TransactionsExample.java
+++ b/docs/src/test/java/sample/javadsl/TransactionsExample.java
@@ -25,7 +25,7 @@ class TransactionsSink extends ConsumerExample {
             .transactionalSource(consumerSettings, Subscriptions.topics("source-topic"))
             .via(business())
             .map(msg ->
-                    new ProducerMessage.Message<byte[], String, ConsumerMessage.PartitionOffset>(
+                    new ProducerMessage.Message<String, byte[], ConsumerMessage.PartitionOffset>(
                             new ProducerRecord<>("sink-topic", msg.record().value()), msg.partitionOffset()))
             .runWith(Producer.transactionalSink(producerSettings, "transactional-id"), materializer);
         // #transactionalSink
@@ -41,7 +41,7 @@ class TransactionsFailureRetryExample extends ConsumerExample {
         // #transactionalFailureRetry
         AtomicReference<Consumer.Control> innerControl = null;
 
-        Source<ProducerMessage.Result<byte[], String, ConsumerMessage.PartitionOffset>,NotUsed> stream =
+        Source<ProducerMessage.Result<String, byte[], ConsumerMessage.PartitionOffset>,NotUsed> stream =
             RestartSource.onFailuresWithBackoff(
                 java.time.Duration.of(3, ChronoUnit.SECONDS), // min backoff
                 java.time.Duration.of(30, ChronoUnit.SECONDS), // max backoff
@@ -49,7 +49,7 @@ class TransactionsFailureRetryExample extends ConsumerExample {
                 () -> Consumer.transactionalSource(consumerSettings, Subscriptions.topics("source-topic"))
                     .via(business())
                     .map(msg ->
-                        new ProducerMessage.Message<byte[], String, ConsumerMessage.PartitionOffset>(
+                        new ProducerMessage.Message<String, byte[], ConsumerMessage.PartitionOffset>(
                             new ProducerRecord<>("sink-topic", msg.record().value()), msg.partitionOffset()))
                     // side effect out the `Control` materialized value because it can't be propagated through the `RestartSource`
                     .mapMaterializedValue(control -> {

--- a/docs/src/test/java/sample/javadsl/TransactionsExample.java
+++ b/docs/src/test/java/sample/javadsl/TransactionsExample.java
@@ -10,9 +10,8 @@ import akka.stream.javadsl.RestartSource;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import scala.concurrent.duration.Duration;
 
-import java.util.concurrent.TimeUnit;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 class TransactionsSink extends ConsumerExample {
@@ -44,8 +43,8 @@ class TransactionsFailureRetryExample extends ConsumerExample {
 
         Source<ProducerMessage.Result<byte[], String, ConsumerMessage.PartitionOffset>,NotUsed> stream =
             RestartSource.onFailuresWithBackoff(
-                Duration.apply(3, TimeUnit.SECONDS), // min backoff
-                Duration.apply(30, TimeUnit.SECONDS), // max backoff
+                java.time.Duration.of(3, ChronoUnit.SECONDS), // min backoff
+                java.time.Duration.of(30, ChronoUnit.SECONDS), // max backoff
                 0.2, // adds 20% "noise" to vary the intervals slightly
                 () -> Consumer.transactionalSource(consumerSettings, Subscriptions.topics("source-topic"))
                     .via(business())

--- a/docs/src/test/scala/sample/scaladsl/TransactionsExample.scala
+++ b/docs/src/test/scala/sample/scaladsl/TransactionsExample.scala
@@ -17,7 +17,7 @@ class TransactionsSink extends ConsumerExample {
         .via(business)
         .map { msg =>
           ProducerMessage.Message(
-            new ProducerRecord[Array[Byte], String]("sink-topic", msg.record.value), msg.partitionOffset)
+            new ProducerRecord[String, Array[Byte]]("sink-topic", msg.record.value), msg.partitionOffset)
         }
         .runWith(Producer.transactionalSink(producerSettings, "transactional-id"))
     // #transactionalSink
@@ -40,7 +40,7 @@ class TransactionsFailureRetryExample extends ConsumerExample {
         .via(business)
         .map { msg =>
           ProducerMessage.Message(
-            new ProducerRecord[Array[Byte], String]("sink-topic", msg.record.value), msg.partitionOffset)
+            new ProducerRecord[String, Array[Byte]]("sink-topic", msg.record.value), msg.partitionOffset)
         }
         // side effect out the `Control` materialized value because it can't be propagated through the `RestartSource`
         .mapMaterializedValue(innerControl = _)


### PR DESCRIPTION
* Create SpecBase
* Split out Retention Period depending test
* Split out Transactions test
* Parallel execution needs to be false as EmbeddedKafka wants to be a Singleton (even though it uses different ports)
