### PR TITLE
Poll wakeups: don't log stack traces until max-wakeups/2 tries

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -63,6 +63,7 @@ akka.kafka.consumer {
   wakeup-timeout = 3s
 
   # After exceeding maxinum wakeups the consumer will stop and the stage will fail.
+  # Setting it to 0 will let it ignore the wakeups and try to get the polling done forever.
   max-wakeups = 10
 
   # If set to a finite duration the consumer will re-send last committed offsets periodically

--- a/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
@@ -296,9 +296,9 @@ private[kafka] class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V])
   def poll(): Unit = {
     val wakeupTask = context.system.scheduler.scheduleOnce(settings.wakeupTimeout) {
       log.warning("KafkaConsumer poll has exceeded wake up timeout ({}ms). Waking up consumer to avoid thread starvation.", settings.wakeupTimeout.toMillis)
-      if (settings.wakeupDebug) {
+      if (settings.wakeupDebug && wakeups > settings.maxWakeups / 2) {
         val stacks = Thread.getAllStackTraces.asScala.map { case (k, v) => s"$k\n ${v.mkString("\n")}" }.mkString("\n\n")
-        log.warning("Wake up has been triggered. Dumping stacks: {}", stacks)
+        log.warning("Wake up has been triggered {} times (See setting akka.kafka.consumer.wakeup-debug). Dumping stacks: {}", wakeups, stacks)
       }
       consumer.wakeup()
     }(context.system.dispatcher)


### PR DESCRIPTION
Following the discussion in #235 where the stack trace for debugging the issue is putting people off, I implemented @patriknw 's suggestion to not print the stack trace for the first half of `max-wakeups'.