### PR TITLE
Rebalance test in a kafka cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       env: mimaReportBinaryIssues
 
     - stage: integration tests
-      script: sbt -jvm-opts .jvmopts-travis core/dockerComposeTest it:test --scale kafka=3
+      script: sbt -jvm-opts .jvmopts-travis "core/dockerComposeTest it:test --scale kafka=3"
 
     - stage: whitesource
       script: sbt -jvm-opts .jvmopts-travis whitesourceCheckPolicies whitesourceUpdate

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ jobs:
       jdk: oraclejdk8
       env: mimaReportBinaryIssues
 
+    - stage: integration tests
+      script: sbt -jvm-opts .jvmopts-travis core/dockerComposeTest it:test --scale kafka=3
+
     - stage: whitesource
       script: sbt -jvm-opts .jvmopts-travis whitesourceCheckPolicies whitesourceUpdate
       jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: scala
 sudo: false
 
+services:
+  - docker
+
 jobs:
   include:
     - stage: test

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ name := "akka-stream-kafka"
 val akkaVersion = "2.5.13"
 val kafkaVersion = "1.0.1"
 val kafkaVersionForDocs = "10"
+val scalatestVersion = "3.0.4"
 
 val kafkaClients = "org.apache.kafka" % "kafka-clients" % kafkaVersion
 
@@ -17,13 +18,12 @@ val commonDependencies = Seq(
 val coreDependencies = Seq(
   "com.typesafe.akka" %% "akka-stream" % akkaVersion,
   kafkaClients,
-  "org.scalatest" %% "scalatest" % "3.0.4" % "test,it",
-  "com.spotify" % "docker-client" % "8.11.5" % "it",
+  "org.scalatest" %% "scalatest" % scalatestVersion % Test,
   "org.reactivestreams" % "reactive-streams-tck" % "1.0.1" % Test,
   "com.novocode" % "junit-interface" % "0.11" % Test,
   "junit" % "junit" % "4.12" % Test,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % "test,it",
+  "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
   "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,
   "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % Test,
   "org.mockito" % "mockito-core" % "2.15.0" % Test,
@@ -120,7 +120,11 @@ lazy val core = project
     AutomaticModuleName.settings("akka.stream.alpakka.kafka"),
     Test/fork := true,
     Test/parallelExecution := false,
-    libraryDependencies ++= commonDependencies ++ coreDependencies,
+    libraryDependencies ++= commonDependencies ++ coreDependencies ++ Seq(
+      "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % "it",
+      "org.scalatest" %% "scalatest" % scalatestVersion % "it",
+      "com.spotify" % "docker-client" % "8.11.5" % "it",
+    ),
     mimaPreviousArtifacts := (20 to 20).map(minor => organization.value %% name.value % s"0.$minor").toSet,
   )
   .settings(Defaults.itSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -17,12 +17,13 @@ val commonDependencies = Seq(
 val coreDependencies = Seq(
   "com.typesafe.akka" %% "akka-stream" % akkaVersion,
   kafkaClients,
-  "org.scalatest" %% "scalatest" % "3.0.4" % Test,
+  "org.scalatest" %% "scalatest" % "3.0.4" % "test,it",
+  "com.spotify" % "docker-client" % "8.11.5" % "it",
   "org.reactivestreams" % "reactive-streams-tck" % "1.0.1" % Test,
   "com.novocode" % "junit-interface" % "0.11" % Test,
   "junit" % "junit" % "4.12" % Test,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
+  "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % "test,it",
   "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,
   "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % Test,
   "org.mockito" % "mockito-core" % "2.15.0" % Test,
@@ -91,6 +92,7 @@ lazy val `alpakka-kafka` =
     .settings(commonSettings)
     .settings(
       skip in publish := true,
+      dockerComposeIgnore := true,
       onLoadMessage :=
           """
             |** Welcome to the Alpakka Kafka connector! **
@@ -111,7 +113,7 @@ lazy val `alpakka-kafka` =
     .aggregate(core, benchmarks, docs)
 
 lazy val core = project
-  .enablePlugins(AutomateHeaderPlugin)
+  .enablePlugins(AutomateHeaderPlugin, DockerCompose)
   .settings(commonSettings)
   .settings(
     name := "akka-stream-kafka",
@@ -121,6 +123,8 @@ lazy val core = project
     libraryDependencies ++= commonDependencies ++ coreDependencies,
     mimaPreviousArtifacts := (20 to 20).map(minor => organization.value %% name.value % s"0.$minor").toSet,
   )
+  .settings(Defaults.itSettings)
+  .configs(IntegrationTest)
 
 lazy val docs = project.in(file("docs"))
   .enablePlugins(ParadoxPlugin)

--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -8,15 +8,13 @@ services:
     ports:
       - "2181:2181"
   kafka:
-    # latest from wurstmeister with https://github.com/wurstmeister/kafka-docker/pull/337
-    image: martynas/wurstmeister-kafka
+    image: wurstmeister/kafka:1.1.0
     ports:
       - "9094"
     environment:
       HOSTNAME_COMMAND: "docker info | grep ^Name: | cut -d' ' -f 2"
       PORT_COMMAND: "docker port `hostname` 9094 | cut -d: -f 2"
-      INSIDE_HOSTNAME_COMMAND: "docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' `hostname`"
-      KAFKA_ADVERTISED_LISTENERS: INSIDE://_{INSIDE_HOSTNAME_COMMAND}:9092,OUTSIDE://_{HOSTNAME_COMMAND}:_{PORT_COMMAND}
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://_{HOSTNAME_COMMAND}:_{PORT_COMMAND}
       KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE

--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -1,0 +1,26 @@
+# See dockerhub for different versions of kafka and zookeeper
+# https://hub.docker.com/r/wurstmeister/kafka/
+# https://hub.docker.com/r/wurstmeister/zookeeper/
+version: '2'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper:3.4.6
+    ports:
+      - "2181:2181"
+  kafka:
+    # latest from wurstmeister with https://github.com/wurstmeister/kafka-docker/pull/337
+    image: martynas/wurstmeister-kafka
+    ports:
+      - "9094"
+    environment:
+      HOSTNAME_COMMAND: "docker info | grep ^Name: | cut -d' ' -f 2"
+      PORT_COMMAND: "docker port `hostname` 9094 | cut -d: -f 2"
+      INSIDE_HOSTNAME_COMMAND: "docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' `hostname`"
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://_{INSIDE_HOSTNAME_COMMAND}:9092,OUTSIDE://_{HOSTNAME_COMMAND}:_{PORT_COMMAND}
+      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      #KAFKA_CREATE_TOPICS: "test:1:1"
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/core/src/it/scala/akka/kafka/RebalanceSpec.scala
+++ b/core/src/it/scala/akka/kafka/RebalanceSpec.scala
@@ -38,7 +38,7 @@ class RebalanceSpec extends TestKit(ActorSystem("RebalanceSpec")) with WordSpecL
 
   "alpakka kafka" should {
 
-    "not loose any mesasges during rebalance" in {
+    "not lose any messages during a rebalance" in {
 
       val producerSettings = ProducerSettings(system, new StringSerializer, new IntegerSerializer)
         .withBootstrapServers(kafkaHost)

--- a/core/src/it/scala/akka/kafka/RebalanceSpec.scala
+++ b/core/src/it/scala/akka/kafka/RebalanceSpec.scala
@@ -1,0 +1,91 @@
+package akka.kafka
+
+import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.kafka.scaladsl.{Consumer, Producer}
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, Source}
+import akka.testkit.TestKit
+import com.spotify.docker.client.DefaultDockerClient
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.{IntegerDeserializer, IntegerSerializer, StringDeserializer, StringSerializer}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+import scala.concurrent.duration._
+
+object RebalanceSpec {
+  def createTopic(): String = UUID.randomUUID().toString
+  val partition0 = 0
+  val defaultKey = "key"
+}
+
+class RebalanceSpec extends TestKit(ActorSystem("RebalanceSpec")) with WordSpecLike with BeforeAndAfterAll with ScalaFutures with Matchers {
+  import RebalanceSpec._
+
+  val kafkaHost = sys.props("kafka_1_9094")
+  val containerId = sys.props("kafka_2_9094_id")
+
+  val docker = new DefaultDockerClient("unix:///var/run/docker.sock")
+
+  implicit val pc = PatienceConfig(10.seconds, 100.millis)
+  implicit val mat = ActorMaterializer()
+
+  override def afterAll() = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  "alpakka kafka" should {
+
+    "not loose any mesasges during rebalance" in {
+
+      val producerSettings = ProducerSettings(system, new StringSerializer, new IntegerSerializer)
+        .withBootstrapServers(kafkaHost)
+
+      val topic = createTopic()
+      val totalMessages = 1000 * 10
+
+      val producer = producerSettings.createKafkaProducer()
+      producer.send(new ProducerRecord(topic, partition0, defaultKey, -1))
+
+      val group = UUID.randomUUID().toString
+      val client = UUID.randomUUID().toString
+
+      val consumerSettings = ConsumerSettings(system, new StringDeserializer, new IntegerDeserializer)
+        .withBootstrapServers(kafkaHost)
+        .withGroupId(group)
+        .withClientId(client)
+
+      val consumer = Consumer.plainSource(consumerSettings, Subscriptions.topics(topic))
+        .takeWhile(_.value() < totalMessages)
+        .scan(0)((c, _) => c + 1)
+        .map { i =>
+          if (i % 1000 == 0) system.log.info(s"Received [$i] messages so far.")
+          i
+        }
+        .runWith(Sink.last)
+
+      // Give some time for the consumer to establish connection to kafka
+      Thread.sleep(5000)
+
+      val result = Source(0 to totalMessages)
+        .map { i =>
+          if (i % 1000 == 0) system.log.info(s"Sent [$i] messages so far.")
+          i
+        }
+        .map(number => new ProducerRecord(topic, partition0, defaultKey, new Integer(number)))
+        .map { c =>
+          if (c.value() == totalMessages / 2) {
+            system.log.info("Stopping one Kafka container")
+            docker.stopContainer(containerId, 0)
+          }
+          c
+        }
+        .runWith(Producer.plainSink(producerSettings))
+
+      result.futureValue
+      consumer.futureValue shouldBe totalMessages
+    }
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,6 @@ addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 addSbtPlugin("lt.dvim.paradox" % "sbt-paradox-local" % "0.1")
 
+// latest version with https://github.com/ehsanyou/sbt-docker-compose/pull/3
+addSbtPlugin("com.github.ehsanyou" % "sbt-docker-compose" % "926a4d83")
+resolvers += Resolver.bintrayIvyRepo("2m", "sbt-plugins")


### PR DESCRIPTION
This required a little modification to the kafka docker images so it is possible to create kafka clusters with the correct configuration for inside and outside listeners.